### PR TITLE
feature/spring-security-hardening

### DIFF
--- a/docs/uml/domain-model.puml
+++ b/docs/uml/domain-model.puml
@@ -1,7 +1,276 @@
 @startuml
 
+class com.tarasantoniuk.finance.banking.bank.entity.Bank {
+	{field} +address : String
+	{field} +id : Long
+	{field} +isActive : Boolean
+	{field} +name : String
+	{field} +phoneNumber : String
+	{field} +swiftCode : String
+	{field} +website : String
+}
 
 
+class com.tarasantoniuk.finance.banking.bankaccount.entity.BankAccount {
+	{field} +accountName : String
+	{field} +accountNumber : String
+	{field} +holderId : Long
+	{field} +holderType : com.tarasantoniuk.finance.banking.bankaccount.enums.AccountHolderType
+	{field} +id : Long
+	{field} +isDefault : Boolean
+	{field} +status : com.tarasantoniuk.finance.banking.bankaccount.enums.AccountStatus
+}
+
+
+class com.tarasantoniuk.finance.banking.bankaccountbalance.entity.BankAccountBalanceSnapshot {
+	{field} +closingBalance : java.math.BigDecimal
+	{field} +createdAt : java.time.LocalDateTime
+	{field} +creditTurnover : java.math.BigDecimal
+	{field} +debitTurnover : java.math.BigDecimal
+	{field} +eventsCount : Integer
+	{field} +id : Long
+	{field} +lastEventId : Long
+	{field} +openingBalance : java.math.BigDecimal
+	{field} +snapshotDateTime : java.time.LocalDateTime
+	{field} +updatedAt : java.time.LocalDateTime
+	{method} #onCreate () : void
+	{method} #onUpdate () : void
+}
+
+
+class com.tarasantoniuk.finance.banking.bankaccounttransaction.entity.BankAccountTransactionEvent {
+	{field} +amount : java.math.BigDecimal
+	{field} +balanceAfter : java.math.BigDecimal
+	{field} +createdAt : java.time.LocalDateTime
+	{field} +description : String
+	{field} +documentId : Long
+	{field} +documentType : String
+	{field} +id : Long
+	{field} +isReversed : Boolean
+	{field} +reversedByEventId : Long
+	{field} +transactionDateTime : java.time.LocalDateTime
+	{field} +transactionType : com.tarasantoniuk.finance.banking.bankaccounttransaction.enums.TransactionType
+	{method} #onCreate () : void
+}
+
+
+class com.tarasantoniuk.finance.banking.bankpayment.entity.BankPayment {
+	{field} +id : Long
+	{field} +outgoingDocumentNumber : String
+	{field} +paymentType : com.tarasantoniuk.finance.banking.bankpayment.enums.PaymentType
+	{method} +getTransactionType () : com.tarasantoniuk.finance.banking.common.enums.TransactionType
+}
+
+
+class com.tarasantoniuk.finance.banking.bankreceipt.entity.BankReceipt {
+	{field} +id : Long
+	{field} +incomingDocumentNumber : String
+	{field} +receiptType : com.tarasantoniuk.finance.banking.bankreceipt.enums.ReceiptType
+	{method} +getTransactionType () : com.tarasantoniuk.finance.banking.common.enums.TransactionType
+}
+
+
+abstract class com.tarasantoniuk.finance.banking.common.entity.MonetaryDocument {
+	{field} +amount : java.math.BigDecimal
+	{field} +bankCommission : java.math.BigDecimal
+	{field} +bankReference : String
+	{field} +externalTransactionId : String
+	{field} +paymentPurpose : String
+	{field} +paymentReference : String
+	{field} +valueDate : java.time.LocalDate
+	{method} +getTotalAmount () : java.math.BigDecimal
+	{method}  {abstract} +getTransactionType () : com.tarasantoniuk.finance.banking.common.enums.TransactionType
+	{method} +hasBankCommission () : boolean
+}
+
+
+abstract class com.tarasantoniuk.finance.common.document.entity.BaseDocument {
+	{field} +cancelledAt : java.time.LocalDateTime
+	{field} +description : String
+	{field} +postedAt : java.time.LocalDateTime
+	{field} +status : com.tarasantoniuk.finance.common.document.enums.DocumentStatus
+	{field} +transactionDateTime : java.time.LocalDateTime
+	{method} +isCancelled () : boolean
+	{method} +isMutable () : boolean
+	{method} +isPosted () : boolean
+	{method} +markAsCancelled () : void
+	{method} +markAsPosted () : void
+}
+
+
+abstract class com.tarasantoniuk.finance.common.entity.BaseEntity {
+	{field} +createdAt : java.time.LocalDateTime
+	{field} +updatedAt : java.time.LocalDateTime
+	{method} #onCreate () : void
+	{method} #onUpdate () : void
+}
+
+
+class com.tarasantoniuk.finance.common.snapshot.entity.SnapshotValidity {
+	{field} +causedByEventId : Long
+	{field} +createdAt : java.time.LocalDateTime
+	{field} +entityId : Long
+	{field} +id : Long
+	{field} +invalidFromDate : java.time.LocalDate
+	{field} +invalidationReason : String
+	{field} +snapshotType : String
+	{field} +status : com.tarasantoniuk.finance.common.snapshot.enums.ValidityStatus
+	{field} +updatedAt : java.time.LocalDateTime
+	{method} +equals ( paramObject1 : Object ) : boolean
+	{method} +hashCode () : int
+	{method} +toString () : String
+}
+
+
+class com.tarasantoniuk.finance.core.accountingpolicy.entity.AccountingPolicy {
+	{field} +depreciationMethod : String
+	{field} +fiscalYearStartMonth : Integer
+	{field} +id : Long
+	{field} +inventoryValuationMethod : String
+	{field} +isActive : Boolean
+	{field} +notes : String
+	{field} +revenueRecognitionMethod : String
+	{field} +vatAccountingMethod : String
+	{field} +year : Integer
+	{method} +equals ( paramObject1 : Object ) : boolean
+	{method} +hashCode () : int
+	{method} +toString () : String
+}
+
+
+class com.tarasantoniuk.finance.core.counterparty.entity.Counterparty {
+	{field} +address : String
+	{field} +code : String
+	{field} +email : String
+	{field} +id : Long
+	{field} +isActive : Boolean
+	{field} +name : String
+	{field} +notes : String
+	{field} +phone : String
+	{field} +taxNumber : String
+	{method} +equals ( paramObject1 : Object ) : boolean
+	{method} +hashCode () : int
+	{method} +toString () : String
+}
+
+
+enum com.tarasantoniuk.finance.core.counterparty.entity.Counterparty$CounterpartyType {
+	{field} +BOTH
+	{field} +CUSTOMER
+	{field} +SUPPLIER
+}
+
+
+class com.tarasantoniuk.finance.core.country.entity.Country {
+	{field} +id : Long
+	{field} +isoCode : String
+	{field} +name : String
+	{field} +phoneCode : String
+	{method} +equals ( paramObject1 : Object ) : boolean
+	{method} +hashCode () : int
+	{method} +toString () : String
+}
+
+
+class com.tarasantoniuk.finance.core.currency.entity.Currency {
+	{field} +code : String
+	{field} +id : Long
+	{field} +isActive : Boolean
+	{field} +minorUnit : Integer
+	{field} +name : String
+	{field} +numericCode : String
+	{field} +symbol : String
+	{method} +equals ( paramObject1 : Object ) : boolean
+	{method} +hashCode () : int
+	{method} +toString () : String
+}
+
+
+class com.tarasantoniuk.finance.core.externalexchangerate.entity.ExternalExchangeRate {
+	{field} +exchangeDate : java.time.LocalDate
+	{field} +id : Long
+	{field} +isActive : Boolean
+	{field} +rate : java.math.BigDecimal
+	{field} +source : String
+	{field} +sourceUrl : String
+	{method} +equals ( paramObject1 : Object ) : boolean
+	{method} +hashCode () : int
+	{method} +toString () : String
+}
+
+
+class com.tarasantoniuk.finance.core.organization.entity.Organization {
+	{field} +address : String
+	{field} +email : String
+	{field} +id : Long
+	{field} +name : String
+	{field} +phone : String
+	{field} +registrationNumber : String
+	{field} +vatNumber : String
+	{method} +equals ( paramObject1 : Object ) : boolean
+	{method} +hashCode () : int
+	{method} +toString () : String
+}
+
+
+class com.tarasantoniuk.finance.security.token.entity.RefreshToken {
+	{field} +expiresAt : java.time.LocalDateTime
+	{field} +id : Long
+	{field} +revoked : boolean
+	{field} +tokenHash : String
+	{field} +used : boolean
+}
+
+
+class com.tarasantoniuk.finance.security.user.entity.User {
+	{field} +email : String
+	{field} +id : Long
+	{field} +isActive : Boolean
+	{field} +password : String
+	{field} +role : com.tarasantoniuk.finance.security.user.enums.UserRole
+}
+
+
+
+
+com.tarasantoniuk.finance.banking.bank.entity.Bank -->  com.tarasantoniuk.finance.core.counterparty.entity.Counterparty : counterparty
+com.tarasantoniuk.finance.banking.bank.entity.Bank -->  com.tarasantoniuk.finance.core.country.entity.Country : country
+com.tarasantoniuk.finance.banking.bank.entity.Bank --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.banking.bankaccount.entity.BankAccount -->  com.tarasantoniuk.finance.banking.bank.entity.Bank : bank
+com.tarasantoniuk.finance.banking.bankaccount.entity.BankAccount -->  com.tarasantoniuk.finance.core.currency.entity.Currency : currency
+com.tarasantoniuk.finance.banking.bankaccount.entity.BankAccount --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.banking.bankaccountbalance.entity.BankAccountBalanceSnapshot -->  com.tarasantoniuk.finance.banking.bankaccount.entity.BankAccount : bankAccount
+com.tarasantoniuk.finance.banking.bankaccountbalance.entity.BankAccountBalanceSnapshot -->  com.tarasantoniuk.finance.core.currency.entity.Currency : currency
+com.tarasantoniuk.finance.banking.bankaccountbalance.entity.BankAccountBalanceSnapshot -->  com.tarasantoniuk.finance.core.organization.entity.Organization : organization
+com.tarasantoniuk.finance.banking.bankaccounttransaction.entity.BankAccountTransactionEvent -->  com.tarasantoniuk.finance.banking.bankaccount.entity.BankAccount : bankAccount
+com.tarasantoniuk.finance.banking.bankaccounttransaction.entity.BankAccountTransactionEvent -->  com.tarasantoniuk.finance.core.currency.entity.Currency : currency
+com.tarasantoniuk.finance.banking.bankaccounttransaction.entity.BankAccountTransactionEvent -->  com.tarasantoniuk.finance.core.organization.entity.Organization : organization
+com.tarasantoniuk.finance.banking.bankpayment.entity.BankPayment --|>  com.tarasantoniuk.finance.banking.common.entity.MonetaryDocument
+com.tarasantoniuk.finance.banking.bankreceipt.entity.BankReceipt --|>  com.tarasantoniuk.finance.banking.common.entity.MonetaryDocument
+com.tarasantoniuk.finance.banking.common.entity.MonetaryDocument -->  com.tarasantoniuk.finance.banking.bankaccount.entity.BankAccount : account
+com.tarasantoniuk.finance.banking.common.entity.MonetaryDocument -->  com.tarasantoniuk.finance.banking.bankaccount.entity.BankAccount : counterpartyBankAccount
+com.tarasantoniuk.finance.banking.common.entity.MonetaryDocument -->  com.tarasantoniuk.finance.core.counterparty.entity.Counterparty : counterparty
+com.tarasantoniuk.finance.banking.common.entity.MonetaryDocument -->  com.tarasantoniuk.finance.core.currency.entity.Currency : currency
+com.tarasantoniuk.finance.banking.common.entity.MonetaryDocument --|>  com.tarasantoniuk.finance.common.document.entity.BaseDocument
+com.tarasantoniuk.finance.common.document.entity.BaseDocument -->  com.tarasantoniuk.finance.core.organization.entity.Organization : organization
+com.tarasantoniuk.finance.common.document.entity.BaseDocument --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.core.accountingpolicy.entity.AccountingPolicy -->  com.tarasantoniuk.finance.core.currency.entity.Currency : currency
+com.tarasantoniuk.finance.core.accountingpolicy.entity.AccountingPolicy -->  com.tarasantoniuk.finance.core.organization.entity.Organization : organization
+com.tarasantoniuk.finance.core.accountingpolicy.entity.AccountingPolicy --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.core.counterparty.entity.Counterparty -->  com.tarasantoniuk.finance.core.counterparty.entity.Counterparty$CounterpartyType : type
+com.tarasantoniuk.finance.core.counterparty.entity.Counterparty -->  com.tarasantoniuk.finance.core.country.entity.Country : country
+com.tarasantoniuk.finance.core.counterparty.entity.Counterparty --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.core.country.entity.Country -->  com.tarasantoniuk.finance.core.currency.entity.Currency : currency
+com.tarasantoniuk.finance.core.country.entity.Country --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.core.currency.entity.Currency --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.core.externalexchangerate.entity.ExternalExchangeRate -->  com.tarasantoniuk.finance.core.currency.entity.Currency : currencyFrom
+com.tarasantoniuk.finance.core.externalexchangerate.entity.ExternalExchangeRate -->  com.tarasantoniuk.finance.core.currency.entity.Currency : currencyTo
+com.tarasantoniuk.finance.core.externalexchangerate.entity.ExternalExchangeRate --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.core.organization.entity.Organization -->  com.tarasantoniuk.finance.core.country.entity.Country : country
+com.tarasantoniuk.finance.core.organization.entity.Organization --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.security.token.entity.RefreshToken -->  com.tarasantoniuk.finance.security.user.entity.User : user
+com.tarasantoniuk.finance.security.token.entity.RefreshToken --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
+com.tarasantoniuk.finance.security.user.entity.User --|>  com.tarasantoniuk.finance.common.entity.BaseEntity
 
 
 @enduml

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,30 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <!-- Caffeine Cache (token blacklisting) -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <!-- Resilience4j Rate Limiting -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+
+        <!-- AOP for Resilience4j annotations -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
         <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/tarasantoniuk/finance/security/audit/ClientIpResolver.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/audit/ClientIpResolver.java
@@ -1,0 +1,24 @@
+package com.tarasantoniuk.finance.security.audit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class ClientIpResolver {
+
+    public String resolve() {
+        ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs == null) {
+            return "unknown";
+        }
+        HttpServletRequest request = attrs.getRequest();
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/audit/SecurityAuditEvent.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/audit/SecurityAuditEvent.java
@@ -1,0 +1,38 @@
+package com.tarasantoniuk.finance.security.audit;
+
+public record SecurityAuditEvent(
+        String action,
+        String email,
+        String ipAddress,
+        boolean success,
+        String details
+) {
+
+    public static SecurityAuditEvent loginSuccess(String email, String ip) {
+        return new SecurityAuditEvent("LOGIN_SUCCESS", email, ip, true, null);
+    }
+
+    public static SecurityAuditEvent loginFailed(String email, String ip, String reason) {
+        return new SecurityAuditEvent("LOGIN_FAILED", email, ip, false, reason);
+    }
+
+    public static SecurityAuditEvent logout(String email, String ip) {
+        return new SecurityAuditEvent("LOGOUT", email, ip, true, null);
+    }
+
+    public static SecurityAuditEvent tokenRefresh(String email, String ip) {
+        return new SecurityAuditEvent("TOKEN_REFRESH", email, ip, true, null);
+    }
+
+    public static SecurityAuditEvent accountLocked(String email, String ip) {
+        return new SecurityAuditEvent("ACCOUNT_LOCKED", email, ip, false, "Too many failed attempts");
+    }
+
+    public static SecurityAuditEvent tokenReuseDetected(String email, String ip) {
+        return new SecurityAuditEvent("TOKEN_REUSE_DETECTED", email, ip, false, "Potential token theft");
+    }
+
+    public static SecurityAuditEvent registration(String email, String ip) {
+        return new SecurityAuditEvent("REGISTRATION", email, ip, true, null);
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/audit/SecurityAuditListener.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/audit/SecurityAuditListener.java
@@ -1,0 +1,22 @@
+package com.tarasantoniuk.finance.security.audit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityAuditListener {
+
+    private static final Logger auditLog = LoggerFactory.getLogger("SECURITY_AUDIT");
+
+    @EventListener
+    public void onSecurityEvent(SecurityAuditEvent event) {
+        auditLog.info("action={} email={} ip={} success={} details={}",
+                event.action(),
+                event.email(),
+                event.ipAddress(),
+                event.success(),
+                event.details() != null ? event.details() : "");
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/controller/AuthController.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.tarasantoniuk.finance.security.auth.dto.LoginRequest;
 import com.tarasantoniuk.finance.security.auth.dto.RegisterRequest;
 import com.tarasantoniuk.finance.security.auth.service.AuthService;
 import com.tarasantoniuk.finance.security.jwt.JwtPrincipal;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -25,19 +26,23 @@ public class AuthController {
     }
 
     @PostMapping("/register")
+    @RateLimiter(name = "auth")
     @Operation(summary = "Register a new user", description = "Creates a new user account and returns access and refresh tokens")
     @ApiResponse(responseCode = "201", description = "User registered successfully")
     @ApiResponse(responseCode = "400", description = "Invalid input data")
     @ApiResponse(responseCode = "409", description = "User with this email already exists")
+    @ApiResponse(responseCode = "429", description = "Too many requests")
     public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(authService.register(request));
     }
 
     @PostMapping("/login")
+    @RateLimiter(name = "auth")
     @Operation(summary = "Authenticate user", description = "Validates credentials and returns access and refresh tokens")
     @ApiResponse(responseCode = "200", description = "Login successful")
     @ApiResponse(responseCode = "401", description = "Invalid email or password")
     @ApiResponse(responseCode = "403", description = "Account is disabled")
+    @ApiResponse(responseCode = "429", description = "Too many requests")
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
     }
@@ -51,13 +56,14 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    @Operation(summary = "Logout user", description = "Revokes all refresh tokens for the authenticated user")
+    @Operation(summary = "Logout user", description = "Revokes all refresh tokens and blacklists the access token")
     @SecurityRequirement(name = "bearerAuth")
     @ApiResponse(responseCode = "204", description = "Logout successful")
     @ApiResponse(responseCode = "403", description = "Not authenticated")
-    public ResponseEntity<Void> logout() {
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorizationHeader) {
         JwtPrincipal principal = (JwtPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        authService.logout(principal.userId());
+        String accessToken = authorizationHeader.substring(7);
+        authService.logout(principal.userId(), accessToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/controller/AuthController.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/controller/AuthController.java
@@ -63,7 +63,7 @@ public class AuthController {
     public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorizationHeader) {
         JwtPrincipal principal = (JwtPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String accessToken = authorizationHeader.substring(7);
-        authService.logout(principal.userId(), accessToken);
+        authService.logout(principal.userId(), principal.email(), accessToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/controller/AuthController.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/controller/AuthController.java
@@ -1,69 +1,129 @@
 package com.tarasantoniuk.finance.security.auth.controller;
 
+import com.tarasantoniuk.finance.security.auth.dto.AccessTokenResponse;
 import com.tarasantoniuk.finance.security.auth.dto.AuthResponse;
+import com.tarasantoniuk.finance.security.auth.dto.ChangePasswordRequest;
 import com.tarasantoniuk.finance.security.auth.dto.LoginRequest;
 import com.tarasantoniuk.finance.security.auth.dto.RegisterRequest;
 import com.tarasantoniuk.finance.security.auth.service.AuthService;
 import com.tarasantoniuk.finance.security.jwt.JwtPrincipal;
+import com.tarasantoniuk.finance.security.jwt.service.JwtService;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final AuthService authService;
+    private static final String REFRESH_TOKEN_COOKIE = "refresh_token";
+    private static final String REFRESH_TOKEN_PATH = "/api/auth/refresh";
 
-    public AuthController(AuthService authService) {
+    private final AuthService authService;
+    private final JwtService jwtService;
+
+    public AuthController(AuthService authService, JwtService jwtService) {
         this.authService = authService;
+        this.jwtService = jwtService;
     }
 
     @PostMapping("/register")
     @RateLimiter(name = "auth")
-    @Operation(summary = "Register a new user", description = "Creates a new user account and returns access and refresh tokens")
+    @Operation(summary = "Register a new user", description = "Creates a new user account and returns access token; refresh token is set as HttpOnly cookie")
     @ApiResponse(responseCode = "201", description = "User registered successfully")
     @ApiResponse(responseCode = "400", description = "Invalid input data")
     @ApiResponse(responseCode = "409", description = "User with this email already exists")
     @ApiResponse(responseCode = "429", description = "Too many requests")
-    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(authService.register(request));
+    public ResponseEntity<AccessTokenResponse> register(@Valid @RequestBody RegisterRequest request,
+                                                        HttpServletResponse response) {
+        AuthResponse authResponse = authService.register(request);
+        addRefreshTokenCookie(response, authResponse.getRefreshToken());
+        return ResponseEntity.status(HttpStatus.CREATED).body(new AccessTokenResponse(authResponse.getAccessToken()));
     }
 
     @PostMapping("/login")
     @RateLimiter(name = "auth")
-    @Operation(summary = "Authenticate user", description = "Validates credentials and returns access and refresh tokens")
+    @Operation(summary = "Authenticate user", description = "Validates credentials and returns access token; refresh token is set as HttpOnly cookie")
     @ApiResponse(responseCode = "200", description = "Login successful")
     @ApiResponse(responseCode = "401", description = "Invalid email or password")
     @ApiResponse(responseCode = "403", description = "Account is disabled")
     @ApiResponse(responseCode = "429", description = "Too many requests")
-    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok(authService.login(request));
+    public ResponseEntity<AccessTokenResponse> login(@Valid @RequestBody LoginRequest request,
+                                                     HttpServletResponse response) {
+        AuthResponse authResponse = authService.login(request);
+        addRefreshTokenCookie(response, authResponse.getRefreshToken());
+        return ResponseEntity.ok(new AccessTokenResponse(authResponse.getAccessToken()));
     }
 
     @PostMapping("/refresh")
-    @Operation(summary = "Refresh access token", description = "Exchanges a valid refresh token for a new access and refresh token pair")
+    @Operation(summary = "Refresh access token", description = "Exchanges a valid refresh token cookie for a new access token and refresh token cookie")
     @ApiResponse(responseCode = "200", description = "Tokens refreshed successfully")
     @ApiResponse(responseCode = "401", description = "Invalid or expired refresh token")
-    public ResponseEntity<AuthResponse> refresh(@RequestHeader("X-Refresh-Token") String refreshToken) {
-        return ResponseEntity.ok(authService.refresh(refreshToken));
+    public ResponseEntity<AccessTokenResponse> refresh(@CookieValue(name = REFRESH_TOKEN_COOKIE) String refreshToken,
+                                                       HttpServletResponse response) {
+        AuthResponse authResponse = authService.refresh(refreshToken);
+        addRefreshTokenCookie(response, authResponse.getRefreshToken());
+        return ResponseEntity.ok(new AccessTokenResponse(authResponse.getAccessToken()));
+    }
+
+    @PostMapping("/change-password")
+    @Operation(summary = "Change password", description = "Change the password of the authenticated user")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponse(responseCode = "204", description = "Password changed successfully")
+    @ApiResponse(responseCode = "401", description = "Current password is incorrect")
+    public ResponseEntity<Void> changePassword(@Valid @RequestBody ChangePasswordRequest request) {
+        JwtPrincipal principal = (JwtPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        authService.changePassword(
+                principal.userId(),
+                request.getCurrentPassword(),
+                request.getNewPassword());
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/logout")
-    @Operation(summary = "Logout user", description = "Revokes all refresh tokens and blacklists the access token")
+    @Operation(summary = "Logout user", description = "Revokes all refresh tokens, blacklists the access token, and clears the refresh token cookie")
     @SecurityRequirement(name = "bearerAuth")
     @ApiResponse(responseCode = "204", description = "Logout successful")
     @ApiResponse(responseCode = "403", description = "Not authenticated")
-    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorizationHeader) {
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorizationHeader,
+                                       HttpServletResponse response) {
         JwtPrincipal principal = (JwtPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String accessToken = authorizationHeader.substring(7);
         authService.logout(principal.userId(), principal.email(), accessToken);
+        clearRefreshTokenCookie(response);
         return ResponseEntity.noContent().build();
+    }
+
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path(REFRESH_TOKEN_PATH)
+                .maxAge(Duration.ofMillis(jwtService.getRefreshTokenExpiration()))
+                .sameSite("Strict")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private void clearRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+                .httpOnly(true)
+                .secure(true)
+                .path(REFRESH_TOKEN_PATH)
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/dto/AccessTokenResponse.java
@@ -1,0 +1,21 @@
+package com.tarasantoniuk.finance.security.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Response containing only the access token; refresh token is set as HttpOnly cookie")
+public class AccessTokenResponse {
+
+    @Schema(description = "JWT access token", example = "eyJhbGciOiJIUzI1NiJ9...")
+    private String accessToken;
+
+    public AccessTokenResponse() {
+    }
+
+    public AccessTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/dto/ChangePasswordRequest.java
@@ -1,0 +1,28 @@
+package com.tarasantoniuk.finance.security.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class ChangePasswordRequest {
+
+    @NotBlank
+    @Schema(description = "Current password", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String currentPassword;
+
+    @NotBlank
+    @Size(min = 8, max = 100)
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#^()\\-_=+])[A-Za-z\\d@$!%*?&#^()\\-_=+]{8,}$",
+            message = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
+    )
+    @Schema(description = "New password", example = "NewSecureP@ss1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String newPassword;
+
+    public String getCurrentPassword() { return currentPassword; }
+    public void setCurrentPassword(String currentPassword) { this.currentPassword = currentPassword; }
+    public String getNewPassword() { return newPassword; }
+    public void setNewPassword(String newPassword) { this.newPassword = newPassword; }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/dto/RegisterRequest.java
@@ -1,17 +1,27 @@
 package com.tarasantoniuk.finance.security.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public class RegisterRequest {
 
     @NotBlank
     @Email
+    @Schema(description = "User email address", example = "user@example.com",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String email;
 
     @NotBlank
     @Size(min = 8, max = 100)
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#^()\\-_=+])[A-Za-z\\d@$!%*?&#^()\\-_=+]{8,}$",
+            message = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
+    )
+    @Schema(description = "User password", example = "SecureP@ss1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String password;
 
     public String getEmail() { return email; }

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/exception/AccountLockedException.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/exception/AccountLockedException.java
@@ -1,0 +1,8 @@
+package com.tarasantoniuk.finance.security.auth.exception;
+
+public class AccountLockedException extends RuntimeException {
+
+    public AccountLockedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/service/AuthService.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.tarasantoniuk.finance.security.auth.dto.RegisterRequest;
 import com.tarasantoniuk.finance.security.jwt.service.JwtService;
 import com.tarasantoniuk.finance.security.token.entity.RefreshToken;
 import com.tarasantoniuk.finance.security.token.repository.RefreshTokenRepository;
+import com.tarasantoniuk.finance.security.token.service.TokenBlacklistService;
 import com.tarasantoniuk.finance.security.user.entity.User;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 import com.tarasantoniuk.finance.security.user.repository.UserRepository;
@@ -26,15 +27,18 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
+    private final TokenBlacklistService tokenBlacklistService;
 
     public AuthService(UserRepository userRepository,
                        RefreshTokenRepository refreshTokenRepository,
                        JwtService jwtService,
-                       PasswordEncoder passwordEncoder) {
+                       PasswordEncoder passwordEncoder,
+                       TokenBlacklistService tokenBlacklistService) {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.jwtService = jwtService;
         this.passwordEncoder = passwordEncoder;
+        this.tokenBlacklistService = tokenBlacklistService;
     }
 
     @Transactional
@@ -81,10 +85,16 @@ public class AuthService {
         RefreshToken refreshToken = refreshTokenRepository.findByTokenHash(tokenHash)
                 .orElseThrow(() -> new InvalidTokenException("Invalid refresh token"));
 
+        if (refreshToken.isUsed()) {
+            refreshTokenRepository.revokeAllByUserId(refreshToken.getUser().getId());
+            throw new InvalidTokenException("Token reuse detected");
+        }
+
         if (refreshToken.isRevoked() || refreshToken.getExpiresAt().isBefore(LocalDateTime.now())) {
             throw new InvalidTokenException("Refresh token is expired or revoked");
         }
 
+        refreshToken.setUsed(true);
         refreshToken.setRevoked(true);
         refreshTokenRepository.save(refreshToken);
 
@@ -92,7 +102,11 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(Long userId) {
+    public void logout(Long userId, String accessToken) {
+        String jti = jwtService.extractClaims(accessToken).getId();
+        if (jti != null) {
+            tokenBlacklistService.blacklist(jti);
+        }
         refreshTokenRepository.revokeAllByUserId(userId);
     }
 

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/service/AuthService.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/service/AuthService.java
@@ -164,6 +164,21 @@ public class AuthService {
         eventPublisher.publishEvent(SecurityAuditEvent.logout(email, clientIpResolver.resolve()));
     }
 
+    @Transactional
+    public void changePassword(Long userId, String currentPassword, String newPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new InvalidCredentialsException("User not found"));
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new InvalidCredentialsException("Current password is incorrect");
+        }
+
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        refreshTokenRepository.revokeAllByUserId(userId);
+    }
+
     private AuthResponse generateTokenPair(User user) {
         String accessToken = jwtService.generateAccessToken(user);
         String rawRefreshToken = jwtService.generateRefreshToken(user);

--- a/src/main/java/com/tarasantoniuk/finance/security/auth/service/AuthService.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/auth/service/AuthService.java
@@ -11,9 +11,15 @@ import com.tarasantoniuk.finance.security.user.entity.User;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 import com.tarasantoniuk.finance.security.user.repository.UserRepository;
 import com.tarasantoniuk.finance.security.auth.exception.AccountDisabledException;
+import com.tarasantoniuk.finance.security.auth.exception.AccountLockedException;
 import com.tarasantoniuk.finance.security.auth.exception.InvalidCredentialsException;
 import com.tarasantoniuk.finance.security.auth.exception.InvalidTokenException;
 import com.tarasantoniuk.finance.security.user.exception.UserAlreadyExistsException;
+import com.tarasantoniuk.finance.security.audit.ClientIpResolver;
+import com.tarasantoniuk.finance.security.audit.SecurityAuditEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,22 +29,33 @@ import java.time.LocalDateTime;
 @Service
 public class AuthService {
 
+    private static final Logger log = LoggerFactory.getLogger(AuthService.class);
+
+    private static final int MAX_FAILED_ATTEMPTS = 5;
+    private static final int LOCK_DURATION_MINUTES = 30;
+
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final TokenBlacklistService tokenBlacklistService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ClientIpResolver clientIpResolver;
 
     public AuthService(UserRepository userRepository,
                        RefreshTokenRepository refreshTokenRepository,
                        JwtService jwtService,
                        PasswordEncoder passwordEncoder,
-                       TokenBlacklistService tokenBlacklistService) {
+                       TokenBlacklistService tokenBlacklistService,
+                       ApplicationEventPublisher eventPublisher,
+                       ClientIpResolver clientIpResolver) {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.jwtService = jwtService;
         this.passwordEncoder = passwordEncoder;
         this.tokenBlacklistService = tokenBlacklistService;
+        this.eventPublisher = eventPublisher;
+        this.clientIpResolver = clientIpResolver;
     }
 
     @Transactional
@@ -53,10 +70,12 @@ public class AuthService {
         user.setRole(UserRole.GUEST);
         userRepository.save(user);
 
+        eventPublisher.publishEvent(SecurityAuditEvent.registration(user.getEmail(), clientIpResolver.resolve()));
+
         return generateTokenPair(user);
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = {InvalidCredentialsException.class, AccountLockedException.class, AccountDisabledException.class})
     public AuthResponse login(LoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new InvalidCredentialsException("Invalid email or password"));
@@ -65,11 +84,38 @@ public class AuthService {
             throw new AccountDisabledException("Account is disabled");
         }
 
+        String clientIp = clientIpResolver.resolve();
+
+        if (user.isLocked()) {
+            eventPublisher.publishEvent(SecurityAuditEvent.loginFailed(request.getEmail(), clientIp, "account_locked"));
+            throw new AccountLockedException(
+                    "Account is locked due to too many failed login attempts. Try again after " + user.getLockedUntil());
+        }
+
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            user.setFailedLoginAttempts(user.getFailedLoginAttempts() + 1);
+
+            if (user.getFailedLoginAttempts() >= MAX_FAILED_ATTEMPTS) {
+                user.setLockedUntil(LocalDateTime.now().plusMinutes(LOCK_DURATION_MINUTES));
+                userRepository.save(user);
+                eventPublisher.publishEvent(SecurityAuditEvent.accountLocked(request.getEmail(), clientIp));
+                throw new AccountLockedException(
+                        "Account locked for " + LOCK_DURATION_MINUTES + " minutes due to too many failed attempts");
+            }
+
+            userRepository.save(user);
+            eventPublisher.publishEvent(SecurityAuditEvent.loginFailed(request.getEmail(), clientIp, "bad_password"));
             throw new InvalidCredentialsException("Invalid email or password");
         }
 
+        if (user.getFailedLoginAttempts() > 0) {
+            user.setFailedLoginAttempts(0);
+            user.setLockedUntil(null);
+        }
+
         refreshTokenRepository.revokeAllByUserId(user.getId());
+
+        eventPublisher.publishEvent(SecurityAuditEvent.loginSuccess(user.getEmail(), clientIp));
 
         return generateTokenPair(user);
     }
@@ -87,6 +133,10 @@ public class AuthService {
 
         if (refreshToken.isUsed()) {
             refreshTokenRepository.revokeAllByUserId(refreshToken.getUser().getId());
+            log.warn("SECURITY: Refresh token reuse detected for userId={}. All tokens revoked.",
+                    refreshToken.getUser().getId());
+            eventPublisher.publishEvent(SecurityAuditEvent.tokenReuseDetected(
+                    refreshToken.getUser().getEmail(), clientIpResolver.resolve()));
             throw new InvalidTokenException("Token reuse detected");
         }
 
@@ -98,16 +148,20 @@ public class AuthService {
         refreshToken.setRevoked(true);
         refreshTokenRepository.save(refreshToken);
 
+        eventPublisher.publishEvent(SecurityAuditEvent.tokenRefresh(
+                refreshToken.getUser().getEmail(), clientIpResolver.resolve()));
+
         return generateTokenPair(refreshToken.getUser());
     }
 
     @Transactional
-    public void logout(Long userId, String accessToken) {
+    public void logout(Long userId, String email, String accessToken) {
         String jti = jwtService.extractClaims(accessToken).getId();
         if (jti != null) {
             tokenBlacklistService.blacklist(jti);
         }
         refreshTokenRepository.revokeAllByUserId(userId);
+        eventPublisher.publishEvent(SecurityAuditEvent.logout(email, clientIpResolver.resolve()));
     }
 
     private AuthResponse generateTokenPair(User user) {

--- a/src/main/java/com/tarasantoniuk/finance/security/config/CorsProperties.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/CorsProperties.java
@@ -1,0 +1,19 @@
+package com.tarasantoniuk.finance.security.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app.cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins;
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,40 @@
+package com.tarasantoniuk.finance.security.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tarasantoniuk.finance.common.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.FORBIDDEN.value(),
+                HttpStatus.FORBIDDEN.getReasonPhrase(),
+                "You do not have permission to access this resource",
+                request.getRequestURI()
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package com.tarasantoniuk.finance.security.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tarasantoniuk.finance.common.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                "Authentication is required to access this resource",
+                request.getRequestURI()
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/config/SecurityConfig.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -24,15 +25,23 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @EnableConfigurationProperties({JwtProperties.class, CorsProperties.class})
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CorsProperties corsProperties;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, CorsProperties corsProperties) {
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          CorsProperties corsProperties,
+                          JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+                          CustomAccessDeniedHandler customAccessDeniedHandler) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.corsProperties = corsProperties;
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+        this.customAccessDeniedHandler = customAccessDeniedHandler;
     }
 
     @Bean
@@ -81,6 +90,10 @@ public class SecurityConfig {
                                 .maxAgeInSeconds(31536000))
                         .contentSecurityPolicy(csp -> csp
                                 .policyDirectives("default-src 'self'; frame-ancestors 'none'"))
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/tarasantoniuk/finance/security/config/SecurityConfig.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/logout").authenticated()
+                        .requestMatchers("/api/auth/change-password").authenticated()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/v1/**").authenticated()

--- a/src/main/java/com/tarasantoniuk/finance/security/config/SecurityConfig.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -23,13 +24,15 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class})
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CorsProperties corsProperties;
 
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, CorsProperties corsProperties) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.corsProperties = corsProperties;
     }
 
     @Bean
@@ -70,6 +73,15 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.deny())
+                        .contentTypeOptions(Customizer.withDefaults())
+                        .httpStrictTransportSecurity(hsts -> hsts
+                                .includeSubDomains(true)
+                                .maxAgeInSeconds(31536000))
+                        .contentSecurityPolicy(csp -> csp
+                                .policyDirectives("default-src 'self'; frame-ancestors 'none'"))
+                )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
@@ -77,7 +89,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:63342"));
+        configuration.setAllowedOrigins(corsProperties.getAllowedOrigins());
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/tarasantoniuk/finance/security/config/SecurityConfig.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/SecurityConfig.java
@@ -55,7 +55,8 @@ public class SecurityConfig {
                         "/v3/api-docs",
                         "/api-docs/**",
                         "/api-docs",
-                        "/webjars/**"
+                        "/webjars/**",
+                        "/actuator/health"
                 )
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/tarasantoniuk/finance/security/config/SecurityExceptionHandler.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/SecurityExceptionHandler.java
@@ -5,6 +5,7 @@ import com.tarasantoniuk.finance.security.auth.exception.AccountDisabledExceptio
 import com.tarasantoniuk.finance.security.auth.exception.InvalidCredentialsException;
 import com.tarasantoniuk.finance.security.auth.exception.InvalidTokenException;
 import com.tarasantoniuk.finance.security.user.exception.UserAlreadyExistsException;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -38,6 +39,12 @@ public class SecurityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInvalidTokenException(
             InvalidTokenException ex, HttpServletRequest request) {
         return buildErrorResponse(HttpStatus.UNAUTHORIZED, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(RequestNotPermitted.class)
+    public ResponseEntity<ErrorResponse> handleRequestNotPermitted(
+            RequestNotPermitted ex, HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.TOO_MANY_REQUESTS, "Too many requests. Please try again later.", request);
     }
 
     private ResponseEntity<ErrorResponse> buildErrorResponse(

--- a/src/main/java/com/tarasantoniuk/finance/security/config/SecurityExceptionHandler.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/config/SecurityExceptionHandler.java
@@ -2,6 +2,7 @@ package com.tarasantoniuk.finance.security.config;
 
 import com.tarasantoniuk.finance.common.ErrorResponse;
 import com.tarasantoniuk.finance.security.auth.exception.AccountDisabledException;
+import com.tarasantoniuk.finance.security.auth.exception.AccountLockedException;
 import com.tarasantoniuk.finance.security.auth.exception.InvalidCredentialsException;
 import com.tarasantoniuk.finance.security.auth.exception.InvalidTokenException;
 import com.tarasantoniuk.finance.security.user.exception.UserAlreadyExistsException;
@@ -32,6 +33,12 @@ public class SecurityExceptionHandler {
     @ExceptionHandler(AccountDisabledException.class)
     public ResponseEntity<ErrorResponse> handleAccountDisabledException(
             AccountDisabledException ex, HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.FORBIDDEN, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(AccountLockedException.class)
+    public ResponseEntity<ErrorResponse> handleAccountLockedException(
+            AccountLockedException ex, HttpServletRequest request) {
         return buildErrorResponse(HttpStatus.FORBIDDEN, ex.getMessage(), request);
     }
 

--- a/src/main/java/com/tarasantoniuk/finance/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/jwt/JwtAuthenticationFilter.java
@@ -63,8 +63,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Long userId = Long.parseLong(claims.getSubject());
         String email = claims.get("email", String.class);
         UserRole role = UserRole.valueOf(claims.get("role", String.class));
+        Long orgId = claims.get("orgId", Long.class);
 
-        JwtPrincipal principal = new JwtPrincipal(userId, email, role);
+        JwtPrincipal principal = new JwtPrincipal(userId, email, role, orgId);
 
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                 principal,

--- a/src/main/java/com/tarasantoniuk/finance/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.tarasantoniuk.finance.security.jwt;
 
 import com.tarasantoniuk.finance.security.jwt.service.JwtService;
+import com.tarasantoniuk.finance.security.token.service.TokenBlacklistService;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -21,9 +22,11 @@ import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
+    private final TokenBlacklistService tokenBlacklistService;
 
-    public JwtAuthenticationFilter(JwtService jwtService) {
+    public JwtAuthenticationFilter(JwtService jwtService, TokenBlacklistService tokenBlacklistService) {
         this.jwtService = jwtService;
+        this.tokenBlacklistService = tokenBlacklistService;
     }
 
     @Override
@@ -51,6 +54,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         Claims claims = jwtService.extractClaims(token);
+
+        String jti = claims.getId();
+        if (jti != null && tokenBlacklistService.isBlacklisted(jti)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         Long userId = Long.parseLong(claims.getSubject());
         String email = claims.get("email", String.class);
         UserRole role = UserRole.valueOf(claims.get("role", String.class));

--- a/src/main/java/com/tarasantoniuk/finance/security/jwt/JwtPrincipal.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/jwt/JwtPrincipal.java
@@ -2,5 +2,5 @@ package com.tarasantoniuk.finance.security.jwt;
 
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 
-public record JwtPrincipal(Long userId, String email, UserRole role) {
+public record JwtPrincipal(Long userId, String email, UserRole role, Long organizationId) {
 }

--- a/src/main/java/com/tarasantoniuk/finance/security/jwt/JwtProperties.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/jwt/JwtProperties.java
@@ -8,6 +8,7 @@ public class JwtProperties {
     private String secret;
     private long accessTokenExpiration;
     private long refreshTokenExpiration;
+    private String issuer = "finance-api";
 
     public String getSecret() { return secret; }
     public void setSecret(String secret) { this.secret = secret; }
@@ -15,4 +16,6 @@ public class JwtProperties {
     public void setAccessTokenExpiration(long accessTokenExpiration) { this.accessTokenExpiration = accessTokenExpiration; }
     public long getRefreshTokenExpiration() { return refreshTokenExpiration; }
     public void setRefreshTokenExpiration(long refreshTokenExpiration) { this.refreshTokenExpiration = refreshTokenExpiration; }
+    public String getIssuer() { return issuer; }
+    public void setIssuer(String issuer) { this.issuer = issuer; }
 }

--- a/src/main/java/com/tarasantoniuk/finance/security/jwt/service/JwtService.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/jwt/service/JwtService.java
@@ -38,11 +38,17 @@ public class JwtService {
     }
 
     public String generateAccessToken(User user) {
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .id(UUID.randomUUID().toString())
                 .subject(user.getId().toString())
                 .claim("email", user.getEmail())
-                .claim("role", user.getRole().name())
+                .claim("role", user.getRole().name());
+
+        if (user.getOrganization() != null) {
+            builder.claim("orgId", user.getOrganization().getId());
+        }
+
+        return builder
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + jwtProperties.getAccessTokenExpiration()))
                 .signWith(secretKey)

--- a/src/main/java/com/tarasantoniuk/finance/security/jwt/service/JwtService.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/jwt/service/JwtService.java
@@ -40,6 +40,7 @@ public class JwtService {
     public String generateAccessToken(User user) {
         var builder = Jwts.builder()
                 .id(UUID.randomUUID().toString())
+                .issuer(jwtProperties.getIssuer())
                 .subject(user.getId().toString())
                 .claim("email", user.getEmail())
                 .claim("role", user.getRole().name());
@@ -58,6 +59,7 @@ public class JwtService {
     public String generateRefreshToken(User user) {
         return Jwts.builder()
                 .id(UUID.randomUUID().toString())
+                .issuer(jwtProperties.getIssuer())
                 .subject(user.getId().toString())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + jwtProperties.getRefreshTokenExpiration()))
@@ -68,6 +70,7 @@ public class JwtService {
     public Claims extractClaims(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
+                .requireIssuer(jwtProperties.getIssuer())
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();

--- a/src/main/java/com/tarasantoniuk/finance/security/token/entity/RefreshToken.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/token/entity/RefreshToken.java
@@ -33,6 +33,9 @@ public class RefreshToken extends BaseEntity {
     @Column(nullable = false)
     private boolean revoked = false;
 
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean used = false;
+
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
     public User getUser() { return user; }
@@ -43,4 +46,6 @@ public class RefreshToken extends BaseEntity {
     public void setExpiresAt(LocalDateTime expiresAt) { this.expiresAt = expiresAt; }
     public boolean isRevoked() { return revoked; }
     public void setRevoked(boolean revoked) { this.revoked = revoked; }
+    public boolean isUsed() { return used; }
+    public void setUsed(boolean used) { this.used = used; }
 }

--- a/src/main/java/com/tarasantoniuk/finance/security/token/service/TokenBlacklistService.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/token/service/TokenBlacklistService.java
@@ -1,0 +1,28 @@
+package com.tarasantoniuk.finance.security.token.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class TokenBlacklistService {
+
+    private final Cache<String, Boolean> blacklist;
+
+    public TokenBlacklistService() {
+        this.blacklist = Caffeine.newBuilder()
+                .expireAfterWrite(15, TimeUnit.MINUTES)
+                .maximumSize(10_000)
+                .build();
+    }
+
+    public void blacklist(String jti) {
+        blacklist.put(jti, Boolean.TRUE);
+    }
+
+    public boolean isBlacklisted(String jti) {
+        return blacklist.getIfPresent(jti) != null;
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/user/controller/AdminUserController.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/user/controller/AdminUserController.java
@@ -1,0 +1,71 @@
+package com.tarasantoniuk.finance.security.user.controller;
+
+import com.tarasantoniuk.finance.common.dto.PageResponse;
+import com.tarasantoniuk.finance.security.user.dto.UserDetailDto;
+import com.tarasantoniuk.finance.security.user.dto.UserSummaryDto;
+import com.tarasantoniuk.finance.security.user.enums.UserRole;
+import com.tarasantoniuk.finance.security.user.service.AdminUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@Tag(name = "Admin - User Management", description = "Admin endpoints for user management")
+@SecurityRequirement(name = "bearerAuth")
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    public AdminUserController(AdminUserService adminUserService) {
+        this.adminUserService = adminUserService;
+    }
+
+    @GetMapping
+    @Operation(summary = "List all users (paginated)")
+    @ApiResponse(responseCode = "200", description = "Users retrieved successfully")
+    @ApiResponse(responseCode = "401", description = "Not authenticated")
+    @ApiResponse(responseCode = "403", description = "Not authorized (requires ADMIN role)")
+    public ResponseEntity<PageResponse<UserSummaryDto>> listUsers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(adminUserService.listUsers(page, size));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get user details")
+    @ApiResponse(responseCode = "200", description = "User retrieved successfully")
+    @ApiResponse(responseCode = "401", description = "Not authenticated")
+    @ApiResponse(responseCode = "403", description = "Not authorized (requires ADMIN role)")
+    @ApiResponse(responseCode = "404", description = "User not found")
+    public ResponseEntity<UserDetailDto> getUser(@PathVariable Long id) {
+        return ResponseEntity.ok(adminUserService.getUser(id));
+    }
+
+    @PatchMapping("/{id}/role")
+    @Operation(summary = "Change user role")
+    @ApiResponse(responseCode = "204", description = "Role changed successfully")
+    @ApiResponse(responseCode = "401", description = "Not authenticated")
+    @ApiResponse(responseCode = "403", description = "Not authorized (requires ADMIN role)")
+    @ApiResponse(responseCode = "404", description = "User not found")
+    public ResponseEntity<Void> changeRole(@PathVariable Long id,
+                                           @RequestParam UserRole role) {
+        adminUserService.changeRole(id, role);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/status")
+    @Operation(summary = "Activate or deactivate user")
+    @ApiResponse(responseCode = "204", description = "Status changed successfully")
+    @ApiResponse(responseCode = "401", description = "Not authenticated")
+    @ApiResponse(responseCode = "403", description = "Not authorized (requires ADMIN role)")
+    @ApiResponse(responseCode = "404", description = "User not found")
+    public ResponseEntity<Void> changeStatus(@PathVariable Long id,
+                                             @RequestParam boolean active) {
+        adminUserService.setActive(id, active);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/user/dto/UserDetailDto.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/user/dto/UserDetailDto.java
@@ -1,0 +1,112 @@
+package com.tarasantoniuk.finance.security.user.dto;
+
+import com.tarasantoniuk.finance.security.user.enums.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "Detailed view of a user for admin management")
+public class UserDetailDto {
+
+    @Schema(description = "User ID", example = "1")
+    private Long id;
+
+    @Schema(description = "User email address", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "User role", example = "USER")
+    private UserRole role;
+
+    @Schema(description = "Whether the account is active", example = "true")
+    private Boolean isActive;
+
+    @Schema(description = "Number of failed login attempts", example = "0")
+    private int failedLoginAttempts;
+
+    @Schema(description = "Account locked until this time, null if not locked")
+    private LocalDateTime lockedUntil;
+
+    @Schema(description = "Organization ID the user belongs to")
+    private Long organizationId;
+
+    @Schema(description = "Account creation timestamp")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "Last update timestamp")
+    private LocalDateTime updatedAt;
+
+    public UserDetailDto() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public UserRole getRole() {
+        return role;
+    }
+
+    public void setRole(UserRole role) {
+        this.role = role;
+    }
+
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public int getFailedLoginAttempts() {
+        return failedLoginAttempts;
+    }
+
+    public void setFailedLoginAttempts(int failedLoginAttempts) {
+        this.failedLoginAttempts = failedLoginAttempts;
+    }
+
+    public LocalDateTime getLockedUntil() {
+        return lockedUntil;
+    }
+
+    public void setLockedUntil(LocalDateTime lockedUntil) {
+        this.lockedUntil = lockedUntil;
+    }
+
+    public Long getOrganizationId() {
+        return organizationId;
+    }
+
+    public void setOrganizationId(Long organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/user/dto/UserSummaryDto.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/user/dto/UserSummaryDto.java
@@ -1,0 +1,62 @@
+package com.tarasantoniuk.finance.security.user.dto;
+
+import com.tarasantoniuk.finance.security.user.enums.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Summary view of a user for admin listings")
+public class UserSummaryDto {
+
+    @Schema(description = "User ID", example = "1")
+    private Long id;
+
+    @Schema(description = "User email address", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "User role", example = "USER")
+    private UserRole role;
+
+    @Schema(description = "Whether the account is active", example = "true")
+    private Boolean isActive;
+
+    public UserSummaryDto() {
+    }
+
+    public UserSummaryDto(Long id, String email, UserRole role, Boolean isActive) {
+        this.id = id;
+        this.email = email;
+        this.role = role;
+        this.isActive = isActive;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public UserRole getRole() {
+        return role;
+    }
+
+    public void setRole(UserRole role) {
+        this.role = role;
+    }
+
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+}

--- a/src/main/java/com/tarasantoniuk/finance/security/user/entity/User.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/user/entity/User.java
@@ -1,8 +1,10 @@
 package com.tarasantoniuk.finance.security.user.entity;
 
 import com.tarasantoniuk.finance.common.entity.BaseEntity;
+import com.tarasantoniuk.finance.core.organization.entity.Organization;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users", indexes = {
@@ -31,6 +33,16 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean isActive = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private Organization organization;
+
+    @Column(nullable = false)
+    private int failedLoginAttempts = 0;
+
+    @Column
+    private LocalDateTime lockedUntil;
 
     public Long getId() {
         return id;
@@ -70,5 +82,33 @@ public class User extends BaseEntity {
 
     public void setIsActive(Boolean isActive) {
         this.isActive = isActive;
+    }
+
+    public Organization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(Organization organization) {
+        this.organization = organization;
+    }
+
+    public int getFailedLoginAttempts() {
+        return failedLoginAttempts;
+    }
+
+    public void setFailedLoginAttempts(int failedLoginAttempts) {
+        this.failedLoginAttempts = failedLoginAttempts;
+    }
+
+    public LocalDateTime getLockedUntil() {
+        return lockedUntil;
+    }
+
+    public void setLockedUntil(LocalDateTime lockedUntil) {
+        this.lockedUntil = lockedUntil;
+    }
+
+    public boolean isLocked() {
+        return lockedUntil != null && lockedUntil.isAfter(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/tarasantoniuk/finance/security/user/service/AdminUserService.java
+++ b/src/main/java/com/tarasantoniuk/finance/security/user/service/AdminUserService.java
@@ -1,0 +1,95 @@
+package com.tarasantoniuk.finance.security.user.service;
+
+import com.tarasantoniuk.finance.common.dto.PageMetadata;
+import com.tarasantoniuk.finance.common.dto.PageResponse;
+import com.tarasantoniuk.finance.common.exception.ResourceNotFoundException;
+import com.tarasantoniuk.finance.security.user.dto.UserDetailDto;
+import com.tarasantoniuk.finance.security.user.dto.UserSummaryDto;
+import com.tarasantoniuk.finance.security.user.entity.User;
+import com.tarasantoniuk.finance.security.user.enums.UserRole;
+import com.tarasantoniuk.finance.security.user.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+
+    public AdminUserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<UserSummaryDto> listUsers(int page, int size) {
+        Page<User> userPage = userRepository.findAll(
+                PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "id")));
+
+        List<UserSummaryDto> content = userPage.getContent().stream()
+                .map(this::toSummaryDto)
+                .toList();
+
+        PageMetadata metadata = PageMetadata.builder()
+                .currentPage(userPage.getNumber())
+                .totalPages(userPage.getTotalPages())
+                .pageSize(userPage.getSize())
+                .totalElements(userPage.getTotalElements())
+                .hasNext(userPage.hasNext())
+                .hasPrevious(userPage.hasPrevious())
+                .build();
+
+        return PageResponse.<UserSummaryDto>builder()
+                .content(content)
+                .metadata(metadata)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public UserDetailDto getUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", id));
+        return toDetailDto(user);
+    }
+
+    public void changeRole(Long id, UserRole role) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", id));
+        user.setRole(role);
+        userRepository.save(user);
+    }
+
+    public void setActive(Long id, boolean active) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", id));
+        user.setIsActive(active);
+        userRepository.save(user);
+    }
+
+    private UserSummaryDto toSummaryDto(User user) {
+        return new UserSummaryDto(
+                user.getId(),
+                user.getEmail(),
+                user.getRole(),
+                user.getIsActive());
+    }
+
+    private UserDetailDto toDetailDto(User user) {
+        UserDetailDto dto = new UserDetailDto();
+        dto.setId(user.getId());
+        dto.setEmail(user.getEmail());
+        dto.setRole(user.getRole());
+        dto.setIsActive(user.getIsActive());
+        dto.setFailedLoginAttempts(user.getFailedLoginAttempts());
+        dto.setLockedUntil(user.getLockedUntil());
+        dto.setOrganizationId(user.getOrganization() != null ? user.getOrganization().getId() : null);
+        dto.setCreatedAt(user.getCreatedAt());
+        dto.setUpdatedAt(user.getUpdatedAt());
+        return dto;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,13 @@ spring.jpa.properties.hibernate.jdbc.batch_size=1000
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
 
+app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000, http://localhost:63342}
+
 app.jwt.secret=${JWT_SECRET}
 app.jwt.access-token-expiration=900000
 app.jwt.refresh-token-expiration=604800000
+
+# Rate limiting
+resilience4j.ratelimiter.instances.auth.limitForPeriod=5
+resilience4j.ratelimiter.instances.auth.limitRefreshPeriod=60s
+resilience4j.ratelimiter.instances.auth.timeoutDuration=0s

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <appender name="SECURITY_AUDIT_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/security-audit.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/security-audit.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>90</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="SECURITY_AUDIT" level="INFO" additivity="false">
+        <appender-ref ref="SECURITY_AUDIT_FILE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/src/test/java/com/tarasantoniuk/finance/security/audit/ClientIpResolverTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/audit/ClientIpResolverTest.java
@@ -1,0 +1,110 @@
+package com.tarasantoniuk.finance.security.audit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClientIpResolverTest {
+
+    private ClientIpResolver clientIpResolver;
+
+    @BeforeEach
+    void setUp() {
+        clientIpResolver = new ClientIpResolver();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    // ========== NO REQUEST CONTEXT ==========
+
+    @Test
+    void resolve_WhenNoRequestContext_ShouldReturnUnknown() {
+        RequestContextHolder.resetRequestAttributes();
+
+        String ip = clientIpResolver.resolve();
+
+        assertEquals("unknown", ip);
+    }
+
+    // ========== X-FORWARDED-FOR HEADER ==========
+
+    @Test
+    void resolve_WhenXForwardedForPresent_ShouldReturnFirstIp() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-For", "203.0.113.50");
+        request.setRemoteAddr("10.0.0.1");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String ip = clientIpResolver.resolve();
+
+        assertEquals("203.0.113.50", ip);
+    }
+
+    @Test
+    void resolve_WhenXForwardedForHasMultipleIps_ShouldReturnFirstOnly() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-For", "203.0.113.50, 70.41.3.18, 150.172.238.178");
+        request.setRemoteAddr("10.0.0.1");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String ip = clientIpResolver.resolve();
+
+        assertEquals("203.0.113.50", ip);
+    }
+
+    @Test
+    void resolve_WhenXForwardedForHasWhitespace_ShouldTrimResult() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-For", "  203.0.113.50  , 70.41.3.18");
+        request.setRemoteAddr("10.0.0.1");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String ip = clientIpResolver.resolve();
+
+        assertEquals("203.0.113.50", ip);
+    }
+
+    @Test
+    void resolve_WhenXForwardedForIsEmpty_ShouldFallBackToRemoteAddr() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-For", "");
+        request.setRemoteAddr("192.168.1.100");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String ip = clientIpResolver.resolve();
+
+        assertEquals("192.168.1.100", ip);
+    }
+
+    // ========== REMOTE ADDR FALLBACK ==========
+
+    @Test
+    void resolve_WhenNoXForwardedFor_ShouldReturnRemoteAddr() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("192.168.1.100");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String ip = clientIpResolver.resolve();
+
+        assertEquals("192.168.1.100", ip);
+    }
+
+    @Test
+    void resolve_WhenRemoteAddrIsIpv6_ShouldReturnIpv6() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("::1");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String ip = clientIpResolver.resolve();
+
+        assertEquals("::1", ip);
+    }
+}

--- a/src/test/java/com/tarasantoniuk/finance/security/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/auth/controller/AuthControllerTest.java
@@ -376,6 +376,21 @@ class AuthControllerTest extends BaseIntegrationTest {
     }
 
     @Test
+    void logout_WhenAccessTokenUsedAfterLogout_ShouldReturn403() throws Exception {
+        AuthResponse tokens = registerUser("blacklist@example.com", "password123");
+
+        // Logout - blacklists the access token
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                .andExpect(status().isNoContent());
+
+        // Try to use blacklisted access token - should fail
+        mockMvc.perform(get("/api/v1/currencies")
+                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void logout_WhenTokenAfterLogout_RefreshShouldFail() throws Exception {
         AuthResponse tokens = registerUser("logout-refresh@example.com", "password123");
 

--- a/src/test/java/com/tarasantoniuk/finance/security/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/auth/controller/AuthControllerTest.java
@@ -148,6 +148,55 @@ class AuthControllerTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.message").value("Invalid email or password"));
     }
 
+    // ========== LOGIN - ACCOUNT LOCKOUT ==========
+
+    @Test
+    void login_WhenAccountLocked_ShouldReturn403() throws Exception {
+        registerUser("locked@example.com", "password123");
+
+        // Lock the account
+        User user = userRepository.findByEmail("locked@example.com").orElseThrow();
+        user.setLockedUntil(java.time.LocalDateTime.now().plusMinutes(30));
+        user.setFailedLoginAttempts(5);
+        userRepository.save(user);
+
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("locked@example.com");
+        loginRequest.setPassword("password123");
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value(
+                        org.hamcrest.Matchers.containsString("Account is locked")));
+    }
+
+    @Test
+    void login_WhenMaxFailedAttempts_ShouldLockAccount() throws Exception {
+        registerUser("lockme@example.com", "password123");
+
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("lockme@example.com");
+        loginRequest.setPassword("wrongpassword");
+
+        // 4 failed attempts - should still get 401
+        for (int i = 0; i < 4; i++) {
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        // 5th failed attempt - account gets locked, should get 403
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value(
+                        org.hamcrest.Matchers.containsString("Account locked for")));
+    }
+
     // ========== REFRESH ==========
 
     @Test
@@ -195,9 +244,9 @@ class AuthControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    void logout_WhenNoToken_ShouldReturn403() throws Exception {
+    void logout_WhenNoToken_ShouldReturn401() throws Exception {
         mockMvc.perform(post("/api/auth/logout"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     // ========== LOGIN - DISABLED ACCOUNT ==========
@@ -294,9 +343,9 @@ class AuthControllerTest extends BaseIntegrationTest {
     // ========== ROLE-BASED ACCESS CONTROL ==========
 
     @Test
-    void getEndpoint_WhenUnauthenticated_ShouldReturn403() throws Exception {
+    void getEndpoint_WhenUnauthenticated_ShouldReturn401() throws Exception {
         mockMvc.perform(get("/api/v1/currencies"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -376,7 +425,7 @@ class AuthControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    void logout_WhenAccessTokenUsedAfterLogout_ShouldReturn403() throws Exception {
+    void logout_WhenAccessTokenUsedAfterLogout_ShouldReturn401() throws Exception {
         AuthResponse tokens = registerUser("blacklist@example.com", "password123");
 
         // Logout - blacklists the access token
@@ -384,10 +433,10 @@ class AuthControllerTest extends BaseIntegrationTest {
                         .header("Authorization", "Bearer " + tokens.getAccessToken()))
                 .andExpect(status().isNoContent());
 
-        // Try to use blacklisted access token - should fail
+        // Try to use blacklisted access token - should fail with 401 (no authentication)
         mockMvc.perform(get("/api/v1/currencies")
                         .header("Authorization", "Bearer " + tokens.getAccessToken()))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/test/java/com/tarasantoniuk/finance/security/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/auth/controller/AuthControllerTest.java
@@ -2,13 +2,14 @@ package com.tarasantoniuk.finance.security.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tarasantoniuk.finance.common.BaseIntegrationTest;
-import com.tarasantoniuk.finance.security.auth.dto.AuthResponse;
+import com.tarasantoniuk.finance.security.auth.dto.AccessTokenResponse;
 import com.tarasantoniuk.finance.security.auth.dto.LoginRequest;
 import com.tarasantoniuk.finance.security.auth.dto.RegisterRequest;
 import com.tarasantoniuk.finance.security.token.repository.RefreshTokenRepository;
 import com.tarasantoniuk.finance.security.user.entity.User;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 import com.tarasantoniuk.finance.security.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,12 +18,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureMockMvc
 class AuthControllerTest extends BaseIntegrationTest {
+
+    private static final String REFRESH_TOKEN_COOKIE = "refresh_token";
 
     @Autowired
     private MockMvc mockMvc;
@@ -45,24 +48,27 @@ class AuthControllerTest extends BaseIntegrationTest {
     // ========== REGISTER ==========
 
     @Test
-    void register_WhenValidRequest_ShouldReturn201WithTokens() throws Exception {
+    void register_WhenValidRequest_ShouldReturn201WithAccessTokenAndRefreshCookie() throws Exception {
         RegisterRequest request = new RegisterRequest();
         request.setEmail("new@example.com");
-        request.setPassword("password123");
+        request.setPassword("SecureP@ss1");
 
-        mockMvc.perform(post("/api/auth/register")
+        MvcResult result = mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.accessToken").isNotEmpty())
-                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+                .andExpect(jsonPath("$.refreshToken").doesNotExist())
+                .andReturn();
+
+        assertRefreshTokenCookiePresent(result);
     }
 
     @Test
     void register_WhenDuplicateEmail_ShouldReturn409() throws Exception {
         RegisterRequest request = new RegisterRequest();
         request.setEmail("duplicate@example.com");
-        request.setPassword("password123");
+        request.setPassword("SecureP@ss1");
 
         // Register first time
         mockMvc.perform(post("/api/auth/register")
@@ -82,7 +88,7 @@ class AuthControllerTest extends BaseIntegrationTest {
     void register_WhenInvalidEmail_ShouldReturn400() throws Exception {
         RegisterRequest request = new RegisterRequest();
         request.setEmail("not-an-email");
-        request.setPassword("password123");
+        request.setPassword("SecureP@ss1");
 
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -102,27 +108,42 @@ class AuthControllerTest extends BaseIntegrationTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    void register_WhenWeakPassword_ShouldReturn400() throws Exception {
+        RegisterRequest request = new RegisterRequest();
+        request.setEmail("valid@example.com");
+        request.setPassword("alllowercase1");
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
     // ========== LOGIN ==========
 
     @Test
-    void login_WhenValidCredentials_ShouldReturn200WithTokens() throws Exception {
-        registerUser("login@example.com", "password123");
+    void login_WhenValidCredentials_ShouldReturn200WithAccessTokenAndRefreshCookie() throws Exception {
+        registerUser("login@example.com", "SecureP@ss1");
 
         LoginRequest loginRequest = new LoginRequest();
         loginRequest.setEmail("login@example.com");
-        loginRequest.setPassword("password123");
+        loginRequest.setPassword("SecureP@ss1");
 
-        mockMvc.perform(post("/api/auth/login")
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken").isNotEmpty())
-                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+                .andExpect(jsonPath("$.refreshToken").doesNotExist())
+                .andReturn();
+
+        assertRefreshTokenCookiePresent(result);
     }
 
     @Test
     void login_WhenWrongPassword_ShouldReturn401() throws Exception {
-        registerUser("wrongpass@example.com", "password123");
+        registerUser("wrongpass@example.com", "SecureP@ss1");
 
         LoginRequest loginRequest = new LoginRequest();
         loginRequest.setEmail("wrongpass@example.com");
@@ -139,7 +160,7 @@ class AuthControllerTest extends BaseIntegrationTest {
     void login_WhenNonExistentEmail_ShouldReturn401() throws Exception {
         LoginRequest loginRequest = new LoginRequest();
         loginRequest.setEmail("nonexistent@example.com");
-        loginRequest.setPassword("password123");
+        loginRequest.setPassword("SecureP@ss1");
 
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -152,7 +173,7 @@ class AuthControllerTest extends BaseIntegrationTest {
 
     @Test
     void login_WhenAccountLocked_ShouldReturn403() throws Exception {
-        registerUser("locked@example.com", "password123");
+        registerUser("locked@example.com", "SecureP@ss1");
 
         // Lock the account
         User user = userRepository.findByEmail("locked@example.com").orElseThrow();
@@ -162,7 +183,7 @@ class AuthControllerTest extends BaseIntegrationTest {
 
         LoginRequest loginRequest = new LoginRequest();
         loginRequest.setEmail("locked@example.com");
-        loginRequest.setPassword("password123");
+        loginRequest.setPassword("SecureP@ss1");
 
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -174,7 +195,7 @@ class AuthControllerTest extends BaseIntegrationTest {
 
     @Test
     void login_WhenMaxFailedAttempts_ShouldLockAccount() throws Exception {
-        registerUser("lockme@example.com", "password123");
+        registerUser("lockme@example.com", "SecureP@ss1");
 
         LoginRequest loginRequest = new LoginRequest();
         loginRequest.setEmail("lockme@example.com");
@@ -197,50 +218,116 @@ class AuthControllerTest extends BaseIntegrationTest {
                         org.hamcrest.Matchers.containsString("Account locked for")));
     }
 
+    // ========== CHANGE PASSWORD ==========
+
+    @Test
+    void changePassword_WhenValidRequest_ShouldReturn204() throws Exception {
+        TokenPair tokens = registerUser("changepass@example.com", "SecureP@ss1");
+
+        String body = objectMapper.writeValueAsString(java.util.Map.of(
+                "currentPassword", "SecureP@ss1",
+                "newPassword", "NewSecureP@ss2"
+        ));
+
+        mockMvc.perform(post("/api/auth/change-password")
+                        .header("Authorization", "Bearer " + tokens.accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNoContent());
+
+        // Login with new password should succeed
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("changepass@example.com");
+        loginRequest.setPassword("NewSecureP@ss2");
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void changePassword_WhenWrongCurrentPassword_ShouldReturn401() throws Exception {
+        TokenPair tokens = registerUser("changepass2@example.com", "SecureP@ss1");
+
+        String body = objectMapper.writeValueAsString(java.util.Map.of(
+                "currentPassword", "WrongP@ss1",
+                "newPassword", "NewSecureP@ss2"
+        ));
+
+        mockMvc.perform(post("/api/auth/change-password")
+                        .header("Authorization", "Bearer " + tokens.accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void changePassword_WhenNotAuthenticated_ShouldReturn401() throws Exception {
+        String body = objectMapper.writeValueAsString(java.util.Map.of(
+                "currentPassword", "SecureP@ss1",
+                "newPassword", "NewSecureP@ss2"
+        ));
+
+        mockMvc.perform(post("/api/auth/change-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
     // ========== REFRESH ==========
 
     @Test
-    void refresh_WhenValidToken_ShouldReturn200WithNewTokens() throws Exception {
-        AuthResponse tokens = registerUser("refresh@example.com", "password123");
+    void refresh_WhenValidCookie_ShouldReturn200WithNewTokens() throws Exception {
+        TokenPair tokens = registerUser("refresh@example.com", "SecureP@ss1");
 
-        mockMvc.perform(post("/api/auth/refresh")
-                        .header("X-Refresh-Token", tokens.getRefreshToken()))
+        MvcResult result = mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, tokens.refreshToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken").isNotEmpty())
-                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+                .andReturn();
+
+        assertRefreshTokenCookiePresent(result);
     }
 
     @Test
     void refresh_WhenInvalidToken_ShouldReturn401() throws Exception {
         mockMvc.perform(post("/api/auth/refresh")
-                        .header("X-Refresh-Token", "invalid-token"))
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, "invalid-token")))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     void refresh_WhenTokenUsedTwice_ShouldReturn401OnSecondUse() throws Exception {
-        AuthResponse tokens = registerUser("reuse@example.com", "password123");
+        TokenPair tokens = registerUser("reuse@example.com", "SecureP@ss1");
 
         // First refresh succeeds
         mockMvc.perform(post("/api/auth/refresh")
-                        .header("X-Refresh-Token", tokens.getRefreshToken()))
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, tokens.refreshToken)))
                 .andExpect(status().isOk());
 
         // Second refresh with same token fails (already revoked)
         mockMvc.perform(post("/api/auth/refresh")
-                        .header("X-Refresh-Token", tokens.getRefreshToken()))
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, tokens.refreshToken)))
                 .andExpect(status().isUnauthorized());
     }
 
     // ========== LOGOUT ==========
 
     @Test
-    void logout_WhenAuthenticated_ShouldReturn204() throws Exception {
-        AuthResponse tokens = registerUser("logout@example.com", "password123");
+    void logout_WhenAuthenticated_ShouldReturn204AndClearCookie() throws Exception {
+        TokenPair tokens = registerUser("logout@example.com", "SecureP@ss1");
 
-        mockMvc.perform(post("/api/auth/logout")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
-                .andExpect(status().isNoContent());
+        MvcResult result = mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer " + tokens.accessToken))
+                .andExpect(status().isNoContent())
+                .andReturn();
+
+        // Verify refresh token cookie is cleared
+        String setCookieHeader = result.getResponse().getHeader("Set-Cookie");
+        assertNotNull(setCookieHeader);
+        assertTrue(setCookieHeader.contains(REFRESH_TOKEN_COOKIE));
+        assertTrue(setCookieHeader.contains("Max-Age=0"));
     }
 
     @Test
@@ -254,14 +341,14 @@ class AuthControllerTest extends BaseIntegrationTest {
     @Test
     void login_WhenAccountDisabled_ShouldReturn403() throws Exception {
         // Register a user then disable them
-        registerUser("disabled@example.com", "password123");
+        registerUser("disabled@example.com", "SecureP@ss1");
         User user = userRepository.findByEmail("disabled@example.com").orElseThrow();
         user.setIsActive(false);
         userRepository.save(user);
 
         LoginRequest loginRequest = new LoginRequest();
         loginRequest.setEmail("disabled@example.com");
-        loginRequest.setPassword("password123");
+        loginRequest.setPassword("SecureP@ss1");
 
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -276,7 +363,7 @@ class AuthControllerTest extends BaseIntegrationTest {
     void register_WhenEmptyEmail_ShouldReturn400() throws Exception {
         RegisterRequest request = new RegisterRequest();
         request.setEmail("");
-        request.setPassword("password123");
+        request.setPassword("SecureP@ss1");
 
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -310,7 +397,7 @@ class AuthControllerTest extends BaseIntegrationTest {
     void login_WhenEmptyEmail_ShouldReturn400() throws Exception {
         LoginRequest loginRequest = new LoginRequest();
         loginRequest.setEmail("");
-        loginRequest.setPassword("password123");
+        loginRequest.setPassword("SecureP@ss1");
 
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -333,9 +420,9 @@ class AuthControllerTest extends BaseIntegrationTest {
     // ========== REFRESH - EDGE CASES ==========
 
     @Test
-    void refresh_WhenMissingHeader_ShouldReturnError() throws Exception {
+    void refresh_WhenMissingCookie_ShouldReturnError() throws Exception {
         mockMvc.perform(post("/api/auth/refresh"))
-                .andExpect(result -> org.junit.jupiter.api.Assertions.assertTrue(
+                .andExpect(result -> assertTrue(
                         result.getResponse().getStatus() >= 400,
                         "Expected error status but got " + result.getResponse().getStatus()));
     }
@@ -350,114 +437,116 @@ class AuthControllerTest extends BaseIntegrationTest {
 
     @Test
     void getEndpoint_WhenGuestRole_ShouldNotReturn403() throws Exception {
-        AuthResponse tokens = registerUser("guest-get@example.com", "password123");
+        TokenPair tokens = registerUser("guest-get@example.com", "SecureP@ss1");
         // New registrations default to GUEST role - GUEST can read but may get 404/200 depending on data
 
         mockMvc.perform(get("/api/v1/currencies")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(result -> assertNotEquals(403, result.getResponse().getStatus()));
     }
 
     @Test
     void postEndpoint_WhenGuestRole_ShouldReturn403() throws Exception {
-        AuthResponse tokens = registerUser("guest-post@example.com", "password123");
+        TokenPair tokens = registerUser("guest-post@example.com", "SecureP@ss1");
         // GUEST role should not be able to POST to /api/v1/**
 
         mockMvc.perform(post("/api/v1/currencies")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     void deleteEndpoint_WhenGuestRole_ShouldReturn403() throws Exception {
-        AuthResponse tokens = registerUser("guest-delete@example.com", "password123");
+        TokenPair tokens = registerUser("guest-delete@example.com", "SecureP@ss1");
 
         mockMvc.perform(delete("/api/v1/currencies/1")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     void deleteEndpoint_WhenUserRole_ShouldReturn403() throws Exception {
         // Create a user with USER role
-        AuthResponse tokens = registerUserWithRole("user-delete@example.com", "password123", UserRole.USER);
+        TokenPair tokens = registerUserWithRole("user-delete@example.com", "SecureP@ss1", UserRole.USER);
 
         mockMvc.perform(delete("/api/v1/currencies/1")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     void postEndpoint_WhenUserRole_ShouldNotReturn403() throws Exception {
-        AuthResponse tokens = registerUserWithRole("user-post@example.com", "password123", UserRole.USER);
+        TokenPair tokens = registerUserWithRole("user-post@example.com", "SecureP@ss1", UserRole.USER);
 
         // USER should be allowed to POST - we don't check for 200 since body may be invalid,
         // but it should not be 403
         mockMvc.perform(post("/api/v1/banks")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Test\",\"swiftCode\":\"TESTCODE\",\"countryId\":1}")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(result -> assertNotEquals(403, result.getResponse().getStatus()));
     }
 
     @Test
     void deleteEndpoint_WhenAdminRole_ShouldNotReturn403() throws Exception {
-        AuthResponse tokens = registerUserWithRole("admin-delete@example.com", "password123", UserRole.ADMIN);
+        TokenPair tokens = registerUserWithRole("admin-delete@example.com", "SecureP@ss1", UserRole.ADMIN);
 
         // ADMIN should be allowed to DELETE - we don't check for 200 since resource may not exist,
         // but it should not be 403
         mockMvc.perform(delete("/api/v1/currencies/99999")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(result -> assertNotEquals(403, result.getResponse().getStatus()));
     }
 
     @Test
     void putEndpoint_WhenGuestRole_ShouldReturn403() throws Exception {
-        AuthResponse tokens = registerUser("guest-put@example.com", "password123");
+        TokenPair tokens = registerUser("guest-put@example.com", "SecureP@ss1");
 
         mockMvc.perform(put("/api/v1/currencies/1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     void logout_WhenAccessTokenUsedAfterLogout_ShouldReturn401() throws Exception {
-        AuthResponse tokens = registerUser("blacklist@example.com", "password123");
+        TokenPair tokens = registerUser("blacklist@example.com", "SecureP@ss1");
 
         // Logout - blacklists the access token
         mockMvc.perform(post("/api/auth/logout")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(status().isNoContent());
 
         // Try to use blacklisted access token - should fail with 401 (no authentication)
         mockMvc.perform(get("/api/v1/currencies")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     void logout_WhenTokenAfterLogout_RefreshShouldFail() throws Exception {
-        AuthResponse tokens = registerUser("logout-refresh@example.com", "password123");
+        TokenPair tokens = registerUser("logout-refresh@example.com", "SecureP@ss1");
 
         // Logout
         mockMvc.perform(post("/api/auth/logout")
-                        .header("Authorization", "Bearer " + tokens.getAccessToken()))
+                        .header("Authorization", "Bearer " + tokens.accessToken))
                 .andExpect(status().isNoContent());
 
         // Try to refresh with the old refresh token - should fail because all tokens are revoked
         mockMvc.perform(post("/api/auth/refresh")
-                        .header("X-Refresh-Token", tokens.getRefreshToken()))
+                        .cookie(new Cookie(REFRESH_TOKEN_COOKIE, tokens.refreshToken)))
                 .andExpect(status().isUnauthorized());
     }
 
     // ========== HELPER METHODS ==========
 
-    private AuthResponse registerUserWithRole(String email, String password, UserRole role) throws Exception {
-        AuthResponse tokens = registerUser(email, password);
+    private record TokenPair(String accessToken, String refreshToken) {}
+
+    private TokenPair registerUserWithRole(String email, String password, UserRole role) throws Exception {
+        registerUser(email, password);
 
         // Update role directly in DB
         User user = userRepository.findByEmail(email).orElseThrow();
@@ -465,20 +554,10 @@ class AuthControllerTest extends BaseIntegrationTest {
         userRepository.save(user);
 
         // Re-login to get tokens with updated role
-        LoginRequest loginRequest = new LoginRequest();
-        loginRequest.setEmail(email);
-        loginRequest.setPassword(password);
-
-        MvcResult result = mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest)))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        return objectMapper.readValue(result.getResponse().getContentAsString(), AuthResponse.class);
+        return loginUser(email, password);
     }
 
-    private AuthResponse registerUser(String email, String password) throws Exception {
+    private TokenPair registerUser(String email, String password) throws Exception {
         RegisterRequest request = new RegisterRequest();
         request.setEmail(email);
         request.setPassword(password);
@@ -489,6 +568,48 @@ class AuthControllerTest extends BaseIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn();
 
-        return objectMapper.readValue(result.getResponse().getContentAsString(), AuthResponse.class);
+        return extractTokenPair(result);
+    }
+
+    private TokenPair loginUser(String email, String password) throws Exception {
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail(email);
+        loginRequest.setPassword(password);
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return extractTokenPair(result);
+    }
+
+    private TokenPair extractTokenPair(MvcResult result) throws Exception {
+        AccessTokenResponse tokenResponse = objectMapper.readValue(
+                result.getResponse().getContentAsString(), AccessTokenResponse.class);
+        String refreshToken = extractRefreshTokenFromCookie(result);
+        return new TokenPair(tokenResponse.getAccessToken(), refreshToken);
+    }
+
+    private String extractRefreshTokenFromCookie(MvcResult result) {
+        String setCookieHeader = result.getResponse().getHeader("Set-Cookie");
+        assertNotNull(setCookieHeader, "Set-Cookie header should be present");
+        assertTrue(setCookieHeader.contains(REFRESH_TOKEN_COOKIE + "="),
+                "Cookie should contain refresh_token");
+
+        // Extract token value from "refresh_token=<value>; ..."
+        String cookiePart = setCookieHeader.split(";")[0];
+        return cookiePart.substring(cookiePart.indexOf("=") + 1);
+    }
+
+    private void assertRefreshTokenCookiePresent(MvcResult result) {
+        String setCookieHeader = result.getResponse().getHeader("Set-Cookie");
+        assertNotNull(setCookieHeader, "Set-Cookie header should be present");
+        assertTrue(setCookieHeader.contains(REFRESH_TOKEN_COOKIE + "="));
+        assertTrue(setCookieHeader.contains("HttpOnly"));
+        assertTrue(setCookieHeader.contains("Secure"));
+        assertTrue(setCookieHeader.contains("SameSite=Strict"));
+        assertTrue(setCookieHeader.contains("Path=/api/auth/refresh"));
     }
 }

--- a/src/test/java/com/tarasantoniuk/finance/security/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/auth/service/AuthServiceTest.java
@@ -10,11 +10,14 @@ import com.tarasantoniuk.finance.security.token.service.TokenBlacklistService;
 import com.tarasantoniuk.finance.security.user.entity.User;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 import com.tarasantoniuk.finance.security.auth.exception.AccountDisabledException;
+import com.tarasantoniuk.finance.security.auth.exception.AccountLockedException;
 import com.tarasantoniuk.finance.security.auth.exception.InvalidCredentialsException;
 import com.tarasantoniuk.finance.security.auth.exception.InvalidTokenException;
 import com.tarasantoniuk.finance.security.user.exception.UserAlreadyExistsException;
 import com.tarasantoniuk.finance.security.user.repository.UserRepository;
+import com.tarasantoniuk.finance.security.audit.ClientIpResolver;
 import io.jsonwebtoken.Claims;
+import org.springframework.context.ApplicationEventPublisher;
 import io.jsonwebtoken.impl.DefaultClaims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +53,12 @@ class AuthServiceTest {
 
     @Mock
     private TokenBlacklistService tokenBlacklistService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private ClientIpResolver clientIpResolver;
 
     @InjectMocks
     private AuthService authService;
@@ -168,6 +177,8 @@ class AuthServiceTest {
                 () -> authService.login(loginRequest));
 
         assertEquals("Invalid email or password", exception.getMessage());
+        assertEquals(1, user.getFailedLoginAttempts());
+        verify(userRepository).save(user);
         verify(refreshTokenRepository, never()).revokeAllByUserId(anyLong());
     }
 
@@ -181,6 +192,60 @@ class AuthServiceTest {
 
         assertEquals("Account is disabled", exception.getMessage());
         verify(refreshTokenRepository, never()).revokeAllByUserId(anyLong());
+    }
+
+    // ========== LOGIN - ACCOUNT LOCKOUT ==========
+
+    @Test
+    void login_WhenAccountLocked_ShouldThrowAccountLockedException() {
+        user.setLockedUntil(LocalDateTime.now().plusMinutes(30));
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(AccountLockedException.class, () -> authService.login(loginRequest));
+        verify(passwordEncoder, never()).matches(anyString(), anyString());
+    }
+
+    @Test
+    void login_WhenMaxFailedAttemptsReached_ShouldLockAccount() {
+        user.setFailedLoginAttempts(4);
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(false);
+
+        assertThrows(AccountLockedException.class, () -> authService.login(loginRequest));
+        assertEquals(5, user.getFailedLoginAttempts());
+        assertNotNull(user.getLockedUntil());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void login_WhenSuccessfulAfterFailedAttempts_ShouldResetCounter() {
+        user.setFailedLoginAttempts(3);
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+        when(jwtService.generateAccessToken(user)).thenReturn("access-token");
+        when(jwtService.generateRefreshToken(user)).thenReturn("refresh-token");
+        when(jwtService.hashToken("refresh-token")).thenReturn("hashed-token");
+        when(jwtService.getRefreshTokenExpiration()).thenReturn(604800000L);
+
+        authService.login(loginRequest);
+
+        assertEquals(0, user.getFailedLoginAttempts());
+        assertNull(user.getLockedUntil());
+    }
+
+    @Test
+    void login_WhenLockExpired_ShouldAllowLogin() {
+        user.setLockedUntil(LocalDateTime.now().minusMinutes(1));
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+        when(jwtService.generateAccessToken(user)).thenReturn("access-token");
+        when(jwtService.generateRefreshToken(user)).thenReturn("refresh-token");
+        when(jwtService.hashToken("refresh-token")).thenReturn("hashed-token");
+        when(jwtService.getRefreshTokenExpiration()).thenReturn(604800000L);
+
+        AuthResponse response = authService.login(loginRequest);
+
+        assertNotNull(response);
     }
 
     // ========== REFRESH ==========
@@ -349,7 +414,7 @@ class AuthServiceTest {
 
         when(jwtService.extractClaims("access-token")).thenReturn(claims);
 
-        authService.logout(1L, "access-token");
+        authService.logout(1L, "test@example.com", "access-token");
 
         verify(tokenBlacklistService).blacklist("test-jti");
         verify(refreshTokenRepository).revokeAllByUserId(1L);
@@ -362,7 +427,7 @@ class AuthServiceTest {
 
         when(jwtService.extractClaims("access-token")).thenReturn(claims);
 
-        authService.logout(1L, "access-token");
+        authService.logout(1L, "test@example.com", "access-token");
 
         verify(tokenBlacklistService, never()).blacklist(anyString());
         verify(refreshTokenRepository).revokeAllByUserId(1L);

--- a/src/test/java/com/tarasantoniuk/finance/security/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/auth/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import com.tarasantoniuk.finance.security.auth.dto.RegisterRequest;
 import com.tarasantoniuk.finance.security.jwt.service.JwtService;
 import com.tarasantoniuk.finance.security.token.entity.RefreshToken;
 import com.tarasantoniuk.finance.security.token.repository.RefreshTokenRepository;
+import com.tarasantoniuk.finance.security.token.service.TokenBlacklistService;
 import com.tarasantoniuk.finance.security.user.entity.User;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 import com.tarasantoniuk.finance.security.auth.exception.AccountDisabledException;
@@ -13,6 +14,8 @@ import com.tarasantoniuk.finance.security.auth.exception.InvalidCredentialsExcep
 import com.tarasantoniuk.finance.security.auth.exception.InvalidTokenException;
 import com.tarasantoniuk.finance.security.user.exception.UserAlreadyExistsException;
 import com.tarasantoniuk.finance.security.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.impl.DefaultClaims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +26,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -42,6 +47,9 @@ class AuthServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private TokenBlacklistService tokenBlacklistService;
 
     @InjectMocks
     private AuthService authService;
@@ -288,12 +296,75 @@ class AuthServiceTest {
         assertFalse(newToken.isRevoked());
     }
 
+    // ========== REFRESH - REUSE DETECTION ==========
+
+    @Test
+    void refresh_WhenTokenAlreadyUsed_ShouldRevokeAllAndThrow() {
+        RefreshToken storedToken = new RefreshToken();
+        storedToken.setUser(user);
+        storedToken.setRevoked(false);
+        storedToken.setUsed(true);
+        storedToken.setExpiresAt(LocalDateTime.now().plusDays(1));
+
+        when(jwtService.isTokenValid("reused-token")).thenReturn(true);
+        when(jwtService.hashToken("reused-token")).thenReturn("hashed-token");
+        when(refreshTokenRepository.findByTokenHash("hashed-token")).thenReturn(Optional.of(storedToken));
+
+        InvalidTokenException exception = assertThrows(InvalidTokenException.class,
+                () -> authService.refresh("reused-token"));
+
+        assertEquals("Token reuse detected", exception.getMessage());
+        verify(refreshTokenRepository).revokeAllByUserId(user.getId());
+    }
+
+    @Test
+    void refresh_WhenValidToken_ShouldMarkAsUsed() {
+        RefreshToken storedToken = new RefreshToken();
+        storedToken.setUser(user);
+        storedToken.setRevoked(false);
+        storedToken.setUsed(false);
+        storedToken.setExpiresAt(LocalDateTime.now().plusDays(1));
+
+        when(jwtService.isTokenValid("raw-token")).thenReturn(true);
+        when(jwtService.hashToken("raw-token")).thenReturn("hashed");
+        when(refreshTokenRepository.findByTokenHash("hashed")).thenReturn(Optional.of(storedToken));
+        when(jwtService.generateAccessToken(user)).thenReturn("new-access");
+        when(jwtService.generateRefreshToken(user)).thenReturn("new-refresh");
+        when(jwtService.hashToken("new-refresh")).thenReturn("new-hashed");
+        when(jwtService.getRefreshTokenExpiration()).thenReturn(604800000L);
+
+        authService.refresh("raw-token");
+
+        assertTrue(storedToken.isUsed());
+        assertTrue(storedToken.isRevoked());
+    }
+
     // ========== LOGOUT ==========
 
     @Test
-    void logout_ShouldRevokeAllUserTokens() {
-        authService.logout(1L);
+    void logout_ShouldBlacklistAccessTokenAndRevokeAllRefreshTokens() {
+        Map<String, Object> claimMap = new HashMap<>();
+        claimMap.put("jti", "test-jti");
+        Claims claims = new DefaultClaims(claimMap);
 
+        when(jwtService.extractClaims("access-token")).thenReturn(claims);
+
+        authService.logout(1L, "access-token");
+
+        verify(tokenBlacklistService).blacklist("test-jti");
+        verify(refreshTokenRepository).revokeAllByUserId(1L);
+    }
+
+    @Test
+    void logout_WhenJtiIsNull_ShouldStillRevokeRefreshTokens() {
+        Map<String, Object> claimMap = new HashMap<>();
+        Claims claims = new DefaultClaims(claimMap);
+
+        when(jwtService.extractClaims("access-token")).thenReturn(claims);
+
+        authService.logout(1L, "access-token");
+
+        verify(tokenBlacklistService, never()).blacklist(anyString());
         verify(refreshTokenRepository).revokeAllByUserId(1L);
     }
 }

--- a/src/test/java/com/tarasantoniuk/finance/security/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/auth/service/AuthServiceTest.java
@@ -78,11 +78,11 @@ class AuthServiceTest {
 
         registerRequest = new RegisterRequest();
         registerRequest.setEmail("test@example.com");
-        registerRequest.setPassword("password123");
+        registerRequest.setPassword("SecureP@ss1");
 
         loginRequest = new LoginRequest();
         loginRequest.setEmail("test@example.com");
-        loginRequest.setPassword("password123");
+        loginRequest.setPassword("SecureP@ss1");
     }
 
     // ========== REGISTER ==========
@@ -90,7 +90,7 @@ class AuthServiceTest {
     @Test
     void register_WhenValidRequest_ShouldReturnAuthResponse() {
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
-        when(passwordEncoder.encode("password123")).thenReturn("encodedPassword");
+        when(passwordEncoder.encode("SecureP@ss1")).thenReturn("encodedPassword");
         when(userRepository.save(any(User.class))).thenReturn(user);
         when(jwtService.generateAccessToken(any(User.class))).thenReturn("access-token");
         when(jwtService.generateRefreshToken(any(User.class))).thenReturn("refresh-token");
@@ -109,7 +109,7 @@ class AuthServiceTest {
     @Test
     void register_ShouldSaveUserWithCorrectFields() {
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
-        when(passwordEncoder.encode("password123")).thenReturn("encodedPassword");
+        when(passwordEncoder.encode("SecureP@ss1")).thenReturn("encodedPassword");
         when(userRepository.save(any(User.class))).thenReturn(user);
         when(jwtService.generateAccessToken(any(User.class))).thenReturn("access-token");
         when(jwtService.generateRefreshToken(any(User.class))).thenReturn("refresh-token");
@@ -142,7 +142,7 @@ class AuthServiceTest {
     @Test
     void login_WhenValidCredentials_ShouldReturnAuthResponse() {
         when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
-        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+        when(passwordEncoder.matches("SecureP@ss1", "encodedPassword")).thenReturn(true);
         when(jwtService.generateAccessToken(user)).thenReturn("access-token");
         when(jwtService.generateRefreshToken(user)).thenReturn("refresh-token");
         when(jwtService.hashToken("refresh-token")).thenReturn("hashed-token");
@@ -171,7 +171,7 @@ class AuthServiceTest {
     @Test
     void login_WhenWrongPassword_ShouldThrowInvalidCredentialsException() {
         when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
-        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(false);
+        when(passwordEncoder.matches("SecureP@ss1", "encodedPassword")).thenReturn(false);
 
         InvalidCredentialsException exception = assertThrows(InvalidCredentialsException.class,
                 () -> authService.login(loginRequest));
@@ -209,7 +209,7 @@ class AuthServiceTest {
     void login_WhenMaxFailedAttemptsReached_ShouldLockAccount() {
         user.setFailedLoginAttempts(4);
         when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
-        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(false);
+        when(passwordEncoder.matches("SecureP@ss1", "encodedPassword")).thenReturn(false);
 
         assertThrows(AccountLockedException.class, () -> authService.login(loginRequest));
         assertEquals(5, user.getFailedLoginAttempts());
@@ -221,7 +221,7 @@ class AuthServiceTest {
     void login_WhenSuccessfulAfterFailedAttempts_ShouldResetCounter() {
         user.setFailedLoginAttempts(3);
         when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
-        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+        when(passwordEncoder.matches("SecureP@ss1", "encodedPassword")).thenReturn(true);
         when(jwtService.generateAccessToken(user)).thenReturn("access-token");
         when(jwtService.generateRefreshToken(user)).thenReturn("refresh-token");
         when(jwtService.hashToken("refresh-token")).thenReturn("hashed-token");
@@ -237,7 +237,7 @@ class AuthServiceTest {
     void login_WhenLockExpired_ShouldAllowLogin() {
         user.setLockedUntil(LocalDateTime.now().minusMinutes(1));
         when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
-        when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+        when(passwordEncoder.matches("SecureP@ss1", "encodedPassword")).thenReturn(true);
         when(jwtService.generateAccessToken(user)).thenReturn("access-token");
         when(jwtService.generateRefreshToken(user)).thenReturn("refresh-token");
         when(jwtService.hashToken("refresh-token")).thenReturn("hashed-token");
@@ -402,6 +402,41 @@ class AuthServiceTest {
 
         assertTrue(storedToken.isUsed());
         assertTrue(storedToken.isRevoked());
+    }
+
+    // ========== CHANGE PASSWORD ==========
+
+    @Test
+    void changePassword_WhenValidCurrentPassword_ShouldUpdateAndRevokeTokens() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("OldP@ss1", "encodedPassword")).thenReturn(true);
+        when(passwordEncoder.encode("NewP@ss1")).thenReturn("newEncodedPassword");
+
+        authService.changePassword(1L, "OldP@ss1", "NewP@ss1");
+
+        assertEquals("newEncodedPassword", user.getPassword());
+        verify(userRepository).save(user);
+        verify(refreshTokenRepository).revokeAllByUserId(1L);
+    }
+
+    @Test
+    void changePassword_WhenWrongCurrentPassword_ShouldThrowInvalidCredentials() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("WrongP@ss1", "encodedPassword")).thenReturn(false);
+
+        InvalidCredentialsException exception = assertThrows(InvalidCredentialsException.class,
+                () -> authService.changePassword(1L, "WrongP@ss1", "NewP@ss1"));
+
+        assertEquals("Current password is incorrect", exception.getMessage());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void changePassword_WhenUserNotFound_ShouldThrowInvalidCredentials() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(InvalidCredentialsException.class,
+                () -> authService.changePassword(99L, "OldP@ss1", "NewP@ss1"));
     }
 
     // ========== LOGOUT ==========

--- a/src/test/java/com/tarasantoniuk/finance/security/config/SecurityExceptionHandlerTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/config/SecurityExceptionHandlerTest.java
@@ -1,0 +1,99 @@
+package com.tarasantoniuk.finance.security.config;
+
+import com.tarasantoniuk.finance.common.ErrorResponse;
+import com.tarasantoniuk.finance.security.auth.exception.AccountDisabledException;
+import com.tarasantoniuk.finance.security.auth.exception.AccountLockedException;
+import com.tarasantoniuk.finance.security.auth.exception.InvalidCredentialsException;
+import com.tarasantoniuk.finance.security.auth.exception.InvalidTokenException;
+import com.tarasantoniuk.finance.security.user.exception.UserAlreadyExistsException;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SecurityExceptionHandlerTest {
+
+    private SecurityExceptionHandler handler;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        handler = new SecurityExceptionHandler();
+        request = new MockHttpServletRequest();
+        request.setRequestURI("/api/auth/login");
+    }
+
+    @Test
+    void handleUserAlreadyExistsException_ShouldReturn409() {
+        UserAlreadyExistsException ex = new UserAlreadyExistsException("test@example.com");
+
+        ResponseEntity<ErrorResponse> response = handler.handleUserAlreadyExistsException(ex, request);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(409, response.getBody().getStatus());
+        assertEquals("/api/auth/login", response.getBody().getPath());
+    }
+
+    @Test
+    void handleInvalidCredentialsException_ShouldReturn401() {
+        InvalidCredentialsException ex = new InvalidCredentialsException("Invalid email or password");
+
+        ResponseEntity<ErrorResponse> response = handler.handleInvalidCredentialsException(ex, request);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(401, response.getBody().getStatus());
+        assertEquals("Invalid email or password", response.getBody().getMessage());
+    }
+
+    @Test
+    void handleAccountDisabledException_ShouldReturn403() {
+        AccountDisabledException ex = new AccountDisabledException("Account is disabled");
+
+        ResponseEntity<ErrorResponse> response = handler.handleAccountDisabledException(ex, request);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(403, response.getBody().getStatus());
+    }
+
+    @Test
+    void handleAccountLockedException_ShouldReturn403() {
+        AccountLockedException ex = new AccountLockedException("Account is locked");
+
+        ResponseEntity<ErrorResponse> response = handler.handleAccountLockedException(ex, request);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(403, response.getBody().getStatus());
+    }
+
+    @Test
+    void handleInvalidTokenException_ShouldReturn401() {
+        InvalidTokenException ex = new InvalidTokenException("Invalid refresh token");
+
+        ResponseEntity<ErrorResponse> response = handler.handleInvalidTokenException(ex, request);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(401, response.getBody().getStatus());
+    }
+
+    @Test
+    void handleRequestNotPermitted_ShouldReturn429() {
+        RequestNotPermitted ex = mock(RequestNotPermitted.class);
+
+        ResponseEntity<ErrorResponse> response = handler.handleRequestNotPermitted(ex, request);
+
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(429, response.getBody().getStatus());
+        assertEquals("Too many requests. Please try again later.", response.getBody().getMessage());
+    }
+}

--- a/src/test/java/com/tarasantoniuk/finance/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/jwt/JwtAuthenticationFilterTest.java
@@ -118,6 +118,7 @@ class JwtAuthenticationFilterTest {
         assertEquals(1L, principal.userId());
         assertEquals("test@example.com", principal.email());
         assertEquals(UserRole.USER, principal.role());
+        assertNull(principal.organizationId());
     }
 
     @Test

--- a/src/test/java/com/tarasantoniuk/finance/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,6 +1,7 @@
 package com.tarasantoniuk.finance.security.jwt;
 
 import com.tarasantoniuk.finance.security.jwt.service.JwtService;
+import com.tarasantoniuk.finance.security.token.service.TokenBlacklistService;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.impl.DefaultClaims;
@@ -30,6 +31,9 @@ class JwtAuthenticationFilterTest {
 
     @Mock
     private JwtService jwtService;
+
+    @Mock
+    private TokenBlacklistService tokenBlacklistService;
 
     @Mock
     private FilterChain filterChain;
@@ -96,12 +100,14 @@ class JwtAuthenticationFilterTest {
         when(jwtService.isTokenValid("valid-token")).thenReturn(true);
 
         Map<String, Object> claimMap = new HashMap<>();
+        claimMap.put("jti", "test-jti");
         claimMap.put("sub", "1");
         claimMap.put("email", "test@example.com");
         claimMap.put("role", "USER");
         Claims claims = new DefaultClaims(claimMap);
 
         when(jwtService.extractClaims("valid-token")).thenReturn(claims);
+        when(tokenBlacklistService.isBlacklisted("test-jti")).thenReturn(false);
 
         filter.doFilterInternal(request, response, filterChain);
 
@@ -112,6 +118,29 @@ class JwtAuthenticationFilterTest {
         assertEquals(1L, principal.userId());
         assertEquals("test@example.com", principal.email());
         assertEquals(UserRole.USER, principal.role());
+    }
+
+    @Test
+    void doFilterInternal_WhenTokenBlacklisted_ShouldNotSetAuthentication() throws ServletException, IOException {
+        request.setRequestURI("/api/v1/currencies");
+        request.addHeader("Authorization", "Bearer blacklisted-token");
+
+        when(jwtService.isTokenValid("blacklisted-token")).thenReturn(true);
+
+        Map<String, Object> claimMap = new HashMap<>();
+        claimMap.put("jti", "blacklisted-jti");
+        claimMap.put("sub", "1");
+        claimMap.put("email", "test@example.com");
+        claimMap.put("role", "USER");
+        Claims claims = new DefaultClaims(claimMap);
+
+        when(jwtService.extractClaims("blacklisted-token")).thenReturn(claims);
+        when(tokenBlacklistService.isBlacklisted("blacklisted-jti")).thenReturn(true);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
     }
 
     @Test

--- a/src/test/java/com/tarasantoniuk/finance/security/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/jwt/service/JwtServiceTest.java
@@ -30,6 +30,7 @@ class JwtServiceTest {
         jwtProperties.setSecret(VALID_SECRET);
         jwtProperties.setAccessTokenExpiration(900000L);
         jwtProperties.setRefreshTokenExpiration(604800000L);
+        jwtProperties.setIssuer("finance-api");
 
         jwtService = new JwtService(jwtProperties);
 
@@ -89,6 +90,37 @@ class JwtServiceTest {
         assertNotNull(claims.getId());
         assertNotNull(claims.getIssuedAt());
         assertNotNull(claims.getExpiration());
+    }
+
+    @Test
+    void generateAccessToken_ShouldContainIssuerClaim() {
+        String token = jwtService.generateAccessToken(user);
+        Claims claims = jwtService.extractClaims(token);
+
+        assertEquals("finance-api", claims.getIssuer());
+    }
+
+    @Test
+    void generateRefreshToken_ShouldContainIssuerClaim() {
+        String token = jwtService.generateRefreshToken(user);
+        Claims claims = jwtService.extractClaims(token);
+
+        assertEquals("finance-api", claims.getIssuer());
+    }
+
+    @Test
+    void extractClaims_WhenWrongIssuer_ShouldThrowException() {
+        // Build a token with a different issuer
+        SecretKey key = Keys.hmacShaKeyFor(VALID_SECRET.getBytes(StandardCharsets.UTF_8));
+        String wrongIssuerToken = Jwts.builder()
+                .issuer("other-service")
+                .subject("1")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 900000))
+                .signWith(key)
+                .compact();
+
+        assertFalse(jwtService.isTokenValid(wrongIssuerToken));
     }
 
     @Test

--- a/src/test/java/com/tarasantoniuk/finance/security/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/jwt/service/JwtServiceTest.java
@@ -1,5 +1,6 @@
 package com.tarasantoniuk.finance.security.jwt.service;
 
+import com.tarasantoniuk.finance.core.organization.entity.Organization;
 import com.tarasantoniuk.finance.security.jwt.JwtProperties;
 import com.tarasantoniuk.finance.security.user.entity.User;
 import com.tarasantoniuk.finance.security.user.enums.UserRole;
@@ -88,6 +89,26 @@ class JwtServiceTest {
         assertNotNull(claims.getId());
         assertNotNull(claims.getIssuedAt());
         assertNotNull(claims.getExpiration());
+    }
+
+    @Test
+    void generateAccessToken_WhenUserHasOrganization_ShouldContainOrgIdClaim() {
+        Organization org = new Organization();
+        org.setId(42L);
+        user.setOrganization(org);
+
+        String token = jwtService.generateAccessToken(user);
+        Claims claims = jwtService.extractClaims(token);
+
+        assertEquals(42L, claims.get("orgId", Long.class));
+    }
+
+    @Test
+    void generateAccessToken_WhenUserHasNoOrganization_ShouldNotContainOrgIdClaim() {
+        String token = jwtService.generateAccessToken(user);
+        Claims claims = jwtService.extractClaims(token);
+
+        assertNull(claims.get("orgId", Long.class));
     }
 
     // ========== GENERATE REFRESH TOKEN ==========

--- a/src/test/java/com/tarasantoniuk/finance/security/token/service/TokenBlacklistServiceTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/token/service/TokenBlacklistServiceTest.java
@@ -1,0 +1,43 @@
+package com.tarasantoniuk.finance.security.token.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TokenBlacklistServiceTest {
+
+    private TokenBlacklistService tokenBlacklistService;
+
+    @BeforeEach
+    void setUp() {
+        tokenBlacklistService = new TokenBlacklistService();
+    }
+
+    @Test
+    void isBlacklisted_WhenTokenNotBlacklisted_ShouldReturnFalse() {
+        assertFalse(tokenBlacklistService.isBlacklisted("some-jti"));
+    }
+
+    @Test
+    void isBlacklisted_WhenTokenBlacklisted_ShouldReturnTrue() {
+        tokenBlacklistService.blacklist("some-jti");
+        assertTrue(tokenBlacklistService.isBlacklisted("some-jti"));
+    }
+
+    @Test
+    void blacklist_ShouldOnlyAffectBlacklistedToken() {
+        tokenBlacklistService.blacklist("jti-1");
+
+        assertTrue(tokenBlacklistService.isBlacklisted("jti-1"));
+        assertFalse(tokenBlacklistService.isBlacklisted("jti-2"));
+    }
+
+    @Test
+    void blacklist_WhenCalledMultipleTimes_ShouldStillBeBlacklisted() {
+        tokenBlacklistService.blacklist("jti-1");
+        tokenBlacklistService.blacklist("jti-1");
+
+        assertTrue(tokenBlacklistService.isBlacklisted("jti-1"));
+    }
+}

--- a/src/test/java/com/tarasantoniuk/finance/security/user/controller/AdminUserControllerTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/user/controller/AdminUserControllerTest.java
@@ -1,0 +1,207 @@
+package com.tarasantoniuk.finance.security.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tarasantoniuk.finance.common.BaseIntegrationTest;
+import com.tarasantoniuk.finance.security.auth.dto.AccessTokenResponse;
+import com.tarasantoniuk.finance.security.auth.dto.RegisterRequest;
+import com.tarasantoniuk.finance.security.token.repository.RefreshTokenRepository;
+import com.tarasantoniuk.finance.security.user.entity.User;
+import com.tarasantoniuk.finance.security.user.enums.UserRole;
+import com.tarasantoniuk.finance.security.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+class AdminUserControllerTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    private String adminAccessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // Create admin user and get token
+        RegisterRequest adminRegister = new RegisterRequest();
+        adminRegister.setEmail("admin@example.com");
+        adminRegister.setPassword("SecureP@ss1");
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(adminRegister)))
+                .andExpect(status().isCreated());
+
+        // Promote to ADMIN
+        User admin = userRepository.findByEmail("admin@example.com").orElseThrow();
+        admin.setRole(UserRole.ADMIN);
+        userRepository.save(admin);
+
+        // Re-login to get token with ADMIN role
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"admin@example.com\",\"password\":\"SecureP@ss1\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        AccessTokenResponse tokenResponse = objectMapper.readValue(
+                loginResult.getResponse().getContentAsString(), AccessTokenResponse.class);
+        adminAccessToken = tokenResponse.getAccessToken();
+
+        // Create a regular user
+        RegisterRequest userRegister = new RegisterRequest();
+        userRegister.setEmail("user@example.com");
+        userRegister.setPassword("SecureP@ss1");
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userRegister)))
+                .andExpect(status().isCreated());
+    }
+
+    // ========== LIST USERS ==========
+
+    @Test
+    void listUsers_WhenAdmin_ShouldReturn200WithUsers() throws Exception {
+        mockMvc.perform(get("/api/admin/users")
+                        .header("Authorization", "Bearer " + adminAccessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.content[0].email").exists())
+                .andExpect(jsonPath("$.content[0].role").exists())
+                .andExpect(jsonPath("$.content[0].isActive").exists())
+                .andExpect(jsonPath("$.metadata.totalElements").value(2));
+    }
+
+    @Test
+    void listUsers_WhenNotAuthenticated_ShouldReturn401() throws Exception {
+        mockMvc.perform(get("/api/admin/users"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void listUsers_WhenNotAdmin_ShouldReturn403() throws Exception {
+        // Login as regular user
+        String userToken = loginAsUser("user@example.com");
+
+        mockMvc.perform(get("/api/admin/users")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // ========== GET USER ==========
+
+    @Test
+    void getUser_WhenAdmin_ShouldReturn200WithDetails() throws Exception {
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+
+        mockMvc.perform(get("/api/admin/users/" + user.getId())
+                        .header("Authorization", "Bearer " + adminAccessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(user.getId()))
+                .andExpect(jsonPath("$.email").value("user@example.com"))
+                .andExpect(jsonPath("$.role").value("GUEST"))
+                .andExpect(jsonPath("$.isActive").value(true))
+                .andExpect(jsonPath("$.failedLoginAttempts").value(0))
+                .andExpect(jsonPath("$.createdAt").exists());
+    }
+
+    @Test
+    void getUser_WhenNotFound_ShouldReturn404() throws Exception {
+        mockMvc.perform(get("/api/admin/users/99999")
+                        .header("Authorization", "Bearer " + adminAccessToken))
+                .andExpect(status().isNotFound());
+    }
+
+    // ========== CHANGE ROLE ==========
+
+    @Test
+    void changeRole_WhenAdmin_ShouldReturn204() throws Exception {
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+
+        mockMvc.perform(patch("/api/admin/users/" + user.getId() + "/role")
+                        .param("role", "USER")
+                        .header("Authorization", "Bearer " + adminAccessToken))
+                .andExpect(status().isNoContent());
+
+        User updated = userRepository.findById(user.getId()).orElseThrow();
+        assertEquals(UserRole.USER, updated.getRole());
+    }
+
+    @Test
+    void changeRole_WhenNotAdmin_ShouldReturn403() throws Exception {
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+        String userToken = loginAsUser("user@example.com");
+
+        mockMvc.perform(patch("/api/admin/users/" + user.getId() + "/role")
+                        .param("role", "ADMIN")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // ========== CHANGE STATUS ==========
+
+    @Test
+    void changeStatus_WhenAdmin_ShouldReturn204() throws Exception {
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+
+        mockMvc.perform(patch("/api/admin/users/" + user.getId() + "/status")
+                        .param("active", "false")
+                        .header("Authorization", "Bearer " + adminAccessToken))
+                .andExpect(status().isNoContent());
+
+        User updated = userRepository.findById(user.getId()).orElseThrow();
+        assertFalse(updated.getIsActive());
+    }
+
+    @Test
+    void changeStatus_WhenNotAdmin_ShouldReturn403() throws Exception {
+        User user = userRepository.findByEmail("user@example.com").orElseThrow();
+        String userToken = loginAsUser("user@example.com");
+
+        mockMvc.perform(patch("/api/admin/users/" + user.getId() + "/status")
+                        .param("active", "false")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+    }
+
+    private String loginAsUser(String email) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"SecureP@ss1\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        AccessTokenResponse response = objectMapper.readValue(
+                result.getResponse().getContentAsString(), AccessTokenResponse.class);
+        return response.getAccessToken();
+    }
+
+    private void assertEquals(UserRole expected, UserRole actual) {
+        org.junit.jupiter.api.Assertions.assertEquals(expected, actual);
+    }
+
+    private void assertFalse(Boolean value) {
+        org.junit.jupiter.api.Assertions.assertFalse(value);
+    }
+}

--- a/src/test/java/com/tarasantoniuk/finance/security/user/service/AdminUserServiceTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/user/service/AdminUserServiceTest.java
@@ -1,0 +1,114 @@
+package com.tarasantoniuk.finance.security.user.service;
+
+import com.tarasantoniuk.finance.common.dto.PageResponse;
+import com.tarasantoniuk.finance.common.exception.ResourceNotFoundException;
+import com.tarasantoniuk.finance.security.user.dto.UserDetailDto;
+import com.tarasantoniuk.finance.security.user.dto.UserSummaryDto;
+import com.tarasantoniuk.finance.security.user.entity.User;
+import com.tarasantoniuk.finance.security.user.enums.UserRole;
+import com.tarasantoniuk.finance.security.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AdminUserService adminUserService;
+
+    @Test
+    void listUsers_ShouldReturnPaginatedResponse() {
+        User user = createUser(1L, "user@example.com", UserRole.USER, true);
+        Page<User> page = new PageImpl<>(List.of(user), PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "id")), 1);
+        when(userRepository.findAll(PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "id")))).thenReturn(page);
+
+        PageResponse<UserSummaryDto> response = adminUserService.listUsers(0, 20);
+
+        assertEquals(1, response.getContent().size());
+        assertEquals("user@example.com", response.getContent().get(0).getEmail());
+        assertEquals(UserRole.USER, response.getContent().get(0).getRole());
+        assertEquals(0, response.getMetadata().getCurrentPage());
+        assertEquals(1, response.getMetadata().getTotalElements());
+    }
+
+    @Test
+    void getUser_WhenExists_ShouldReturnDetailDto() {
+        User user = createUser(1L, "user@example.com", UserRole.USER, true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        UserDetailDto dto = adminUserService.getUser(1L);
+
+        assertEquals(1L, dto.getId());
+        assertEquals("user@example.com", dto.getEmail());
+        assertEquals(UserRole.USER, dto.getRole());
+        assertTrue(dto.getIsActive());
+    }
+
+    @Test
+    void getUser_WhenNotFound_ShouldThrowException() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> adminUserService.getUser(99L));
+    }
+
+    @Test
+    void changeRole_WhenUserExists_ShouldUpdateRole() {
+        User user = createUser(1L, "user@example.com", UserRole.USER, true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        adminUserService.changeRole(1L, UserRole.ADMIN);
+
+        assertEquals(UserRole.ADMIN, user.getRole());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void changeRole_WhenNotFound_ShouldThrowException() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> adminUserService.changeRole(99L, UserRole.ADMIN));
+    }
+
+    @Test
+    void setActive_WhenUserExists_ShouldUpdateStatus() {
+        User user = createUser(1L, "user@example.com", UserRole.USER, true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        adminUserService.setActive(1L, false);
+
+        assertFalse(user.getIsActive());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void setActive_WhenNotFound_ShouldThrowException() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> adminUserService.setActive(99L, false));
+    }
+
+    private User createUser(Long id, String email, UserRole role, boolean active) {
+        User user = new User();
+        user.setId(id);
+        user.setEmail(email);
+        user.setRole(role);
+        user.setIsActive(active);
+        return user;
+    }
+}

--- a/src/test/java/com/tarasantoniuk/finance/security/user/service/AdminUserServiceTest.java
+++ b/src/test/java/com/tarasantoniuk/finance/security/user/service/AdminUserServiceTest.java
@@ -1,5 +1,6 @@
 package com.tarasantoniuk.finance.security.user.service;
 
+import com.tarasantoniuk.finance.core.organization.entity.Organization;
 import com.tarasantoniuk.finance.common.dto.PageResponse;
 import com.tarasantoniuk.finance.common.exception.ResourceNotFoundException;
 import com.tarasantoniuk.finance.security.user.dto.UserDetailDto;
@@ -101,6 +102,30 @@ class AdminUserServiceTest {
         when(userRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThrows(ResourceNotFoundException.class, () -> adminUserService.setActive(99L, false));
+    }
+
+    @Test
+    void getUser_WhenUserHasOrganization_ShouldReturnOrgId() {
+        User user = createUser(1L, "user@example.com", UserRole.USER, true);
+        Organization org = new Organization();
+        org.setId(42L);
+        user.setOrganization(org);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        UserDetailDto dto = adminUserService.getUser(1L);
+
+        assertEquals(42L, dto.getOrganizationId());
+    }
+
+    @Test
+    void getUser_WhenUserHasNoOrganization_ShouldReturnNullOrgId() {
+        User user = createUser(1L, "user@example.com", UserRole.USER, true);
+        user.setOrganization(null);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        UserDetailDto dto = adminUserService.getUser(1L);
+
+        assertNull(dto.getOrganizationId());
     }
 
     private User createUser(Long id, String email, UserRole role, boolean active) {

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -18,3 +18,9 @@ ecb.sync.initial-load=false
 app.jwt.secret=test-secret-key-for-jwt-must-be-at-least-32-bytes-long
 app.jwt.access-token-expiration=900000
 app.jwt.refresh-token-expiration=604800000
+# CORS
+app.cors.allowed-origins=http://localhost:3000
+# Rate limiting - high limits for tests
+resilience4j.ratelimiter.instances.auth.limitForPeriod=1000
+resilience4j.ratelimiter.instances.auth.limitRefreshPeriod=1s
+resilience4j.ratelimiter.instances.auth.timeoutDuration=0s


### PR DESCRIPTION
# feat(security): comprehensive security hardening for authentication and authorization

# Description

This PR implements a complete security hardening pass across the authentication and authorization subsystem. It covers 15 improvements spanning MUST HAVE infrastructure (HTTP headers, CORS, rate limiting, token management), SHOULD HAVE protections (account lockout, audit logging, proper error responses, method-level security, multi-tenancy foundation), and NICE TO HAVE features (password strength validation, HttpOnly cookies, change password, admin user management, JWT issuer claims). All changes include unit and integration tests. This is a **breaking API change** — the refresh token is now delivered via HttpOnly cookie instead of the response body.

# What Was Changed

### Infrastructure & Headers
- Added HTTP security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, Content-Security-Policy, Referrer-Policy, Permissions-Policy)
- Moved CORS allowed origins from hardcoded values to `application.properties` configuration
- Added rate limiting on auth endpoints using Resilience4j (prevents brute-force and credential stuffing)

### Token Management
- Added access token blacklisting with Caffeine in-memory cache (tokens invalidated on logout)
- Added refresh token reuse detection (detects stolen tokens, revokes entire token family)
- Added JWT issuer claim (`finance-api`) with validation — rejects tokens from other services
- Moved refresh token from response body to HttpOnly, Secure, SameSite=Strict cookie scoped to `/api/auth/refresh`

### Authentication & Authorization
- Added account lockout after 5 failed login attempts (30-minute lock duration)
- Added proper JSON error responses for 401 Unauthorized and 403 Forbidden (replaces Spring default HTML)
- Enabled method-level security with `@EnableMethodSecurity` (`@PreAuthorize`, `@PostAuthorize`, `@Secured`)
- Added password strength validation requiring uppercase, lowercase, digit, and special character (min 8 chars)
- Added change password endpoint (`POST /api/auth/change-password`) with current password verification and token revocation

### Admin & Multi-Tenancy
- Added admin user management endpoints (`GET/PATCH /api/admin/users`) — list, view, change role, activate/deactivate
- Added user-to-organization binding (nullable `@ManyToOne`) with `orgId` JWT claim propagation — foundation for multi-tenant data isolation

### Observability
- Added security audit logging via Spring events — all auth events (login, logout, register, refresh, lockout, token reuse) logged with client IP, email, and timestamp
- Added dedicated security audit log file with 90-day rolling retention (`logback-spring.xml`)
- Added `ClientIpResolver` supporting X-Forwarded-For proxy chains

### Bug Fix
- Permitted actuator health endpoint (`/actuator/health`) without authentication

# Security Improvements

| Category | Improvement | Protection Against |
|----------|------------|-------------------|
| Transport | HTTP security headers | XSS, clickjacking, MIME sniffing, protocol downgrade |
| Transport | CORS origins in config | Cross-origin attacks, misconfiguration |
| Authentication | Account lockout (5 attempts / 30 min) | Brute-force attacks, credential stuffing |
| Authentication | Password strength validation | Weak password exploitation |
| Authentication | Rate limiting on auth endpoints | Brute-force, API abuse, DDoS |
| Token Security | Access token blacklisting (Caffeine cache) | Use of revoked tokens after logout |
| Token Security | Refresh token reuse detection | Stolen token replay attacks |
| Token Security | HttpOnly Secure SameSite=Strict cookie | XSS token theft, CSRF |
| Token Security | JWT issuer claim validation | Cross-service token injection |
| Authorization | Method-level security enabled | Privilege escalation (defense-in-depth) |
| Authorization | Proper 401/403 JSON responses | Information leakage from default error pages |
| Multi-Tenancy | User-organization binding + JWT claim | Cross-tenant data access (foundation) |
| Audit | Security event logging with IP tracking | Incident response, forensic investigation |

# UX Improvements

- **Structured error responses**: 401/403 errors now return consistent JSON `ErrorResponse` instead of Spring's default HTML/whitepage
- **Rate limit feedback**: 429 Too Many Requests with clear message enables proper client retry behavior
- **Change password flow**: Users can change their own password with current password verification
- **Admin user management**: Admins can list users, view details, change roles, and activate/deactivate accounts
- **Swagger documentation**: All new DTOs annotated with `@Schema` descriptions and examples

# Test Coverage Impact

### New Tests Added: +28 tests (15 unit + 13 integration)

| Class | Before (Instr/Branch/Line) | After (Instr/Branch/Line) |
|-------|---------------------------|--------------------------|
| ClientIpResolver | 62% / 33% / 80% | **100% / 100% / 100%** |
| SecurityExceptionHandler | 90% / N/A / 92% | **100% / N/A / 100%** |
| AdminUserService | 98% / 50% / 100% | **100% / 100% / 100%** |
| JwtService | 96% / 100% / 96% | 96% / 100% / 96% (accepted risk) |
| JwtAuthenticationFilter | 100% / 95% / 100% | 100% / 95% / 100% (dead code) |
| AuthService | 100% / 100% / 100% | 100% / 100% / 100% |
| AuthController | 100% / N/A / 100% | 100% / N/A / 100% |
| AdminUserController | 100% / N/A / 100% | 100% / N/A / 100% |
| TokenBlacklistService | 100% / 100% / 100% | 100% / 100% / 100% |
| SecurityAuditListener | 100% / 100% / 100% | 100% / 100% / 100% |

**Security subsystem aggregate**: 13/18 classes at 100% instruction coverage. 2 accepted risk gaps documented (SHA-256 impossible exception, dead code branch).

### Accepted Risk Gaps
1. **JwtService.hashToken** — `NoSuchAlgorithmException` catch block for SHA-256 (mandatory JVM algorithm, impossible to trigger)
2. **JwtAuthenticationFilter.shouldNotFilter** — redundant `path.equals("/swagger-ui.html")` already caught by `startsWith("/swagger-ui")`

# All Commits (chronological order)

| # | Hash | Message |
|---|------|---------|
| 1 | `7b4460e` | feat(security): add HTTP security headers |
| 2 | `77c2704` | feat(security): move CORS allowed origins to application.properties |
| 3 | `6195c91` | feat(security): add rate limiting on auth endpoints |
| 4 | `7231b90` | feat(security): add refresh token reuse detection |
| 5 | `e744a8d` | feat(security): add access token blacklisting with Caffeine cache |
| 6 | `6eedbf9` | feat(security): add audit logging for security events |
| 7 | `c2a5641` | feat(security): add account lockout after failed login attempts |
| 8 | `c3e1a82` | feat(security): enable method-level security with @EnableMethodSecurity |
| 9 | `f3e7a22` | feat(security): add proper JSON responses for 401/403 authentication errors |
| 10 | `7e6a1a0` | feat(security): add user-to-organization binding for multi-tenancy support |
| 11 | `b6f1b5b` | feat(security): add admin user management endpoints |
| 12 | `78e1aa5` | feat(security): add change password endpoint for authenticated users |
| 13 | `f72c78a` | feat(security): move refresh token to HttpOnly cookie |
| 14 | `0f24f4e` | feat(security): add issuer claim to JWT tokens with validation |
| 15 | `4da3b5f` | feat(security): add password strength validation on registration |
| 16 | `7ff357b` | fix: permit actuator health endpoint without authentication |

# How to Test Manually

### 1. Start the application
```bash
mvn spring-boot:run -Dspring-boot.run.profiles=dev
```

### 2. Run all tests (requires Docker for Testcontainers)
```bash
mvn clean test
```

### 3. Test security headers
```bash
curl -I http://localhost:8080/actuator/health
# Verify: X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security, etc.
```

### 4. Test authentication flow (HttpOnly cookie)
```bash
# Register
curl -X POST http://localhost:8080/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","password":"SecureP@ss1","firstName":"Test","lastName":"User"}' \
  -c cookies.txt -v
# Verify: response body has accessToken only, Set-Cookie header has refreshToken with HttpOnly;Secure;SameSite=Strict

# Login
curl -X POST http://localhost:8080/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","password":"SecureP@ss1"}' \
  -c cookies.txt -v

# Refresh (uses cookie)
curl -X POST http://localhost:8080/api/auth/refresh \
  -b cookies.txt -v
```

### 5. Test password strength validation
```bash
# Should fail with 400
curl -X POST http://localhost:8080/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"email":"weak@example.com","password":"weak","firstName":"Test","lastName":"User"}'
```

### 6. Test account lockout
```bash
# Send 5 wrong password attempts, 6th should return 403 with lockout message
for i in {1..6}; do
  curl -X POST http://localhost:8080/api/auth/login \
    -H "Content-Type: application/json" \
    -d '{"email":"test@example.com","password":"WrongPass1!"}'
  echo ""
done
```

### 7. Test rate limiting
```bash
# Send rapid requests — should get 429 after limit exceeded
for i in {1..25}; do
  curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8080/api/auth/login \
    -H "Content-Type: application/json" \
    -d '{"email":"test@example.com","password":"SecureP@ss1"}'
done
```

### 8. Test change password
```bash
curl -X POST http://localhost:8080/api/auth/change-password \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <access_token>" \
  -d '{"currentPassword":"SecureP@ss1","newPassword":"NewSecureP@ss2"}'
```

### 9. Test admin endpoints (requires ADMIN role)
```bash
curl http://localhost:8080/api/admin/users \
  -H "Authorization: Bearer <admin_access_token>"
```

### 10. Test 401/403 JSON responses
```bash
# 401 — no token
curl http://localhost:8080/api/admin/users -v
# Should return JSON: {"status":401,"message":"Unauthorized","timestamp":"..."}

# 403 — non-admin token
curl http://localhost:8080/api/admin/users \
  -H "Authorization: Bearer <user_access_token>" -v
# Should return JSON: {"status":403,"message":"Forbidden","timestamp":"..."}
```

### 11. Verify security audit logs
```bash
# After performing auth actions, check the security audit log
cat logs/security-audit.log
# Should contain entries for LOGIN_SUCCESS, LOGIN_FAILED, REGISTRATION, etc. with client IPs
```

### 12. Test actuator health (no auth required)
```bash
curl http://localhost:8080/actuator/health
# Should return 200 OK without authentication
```
